### PR TITLE
Added RegularGivingIsdefault to donation options

### DIFF
--- a/src/DemoSite/DemoSite.Web/uSync/v9/ContentTypes/donationoption.config
+++ b/src/DemoSite/DemoSite.Web/uSync/v9/ContentTypes/donationoption.config
@@ -117,6 +117,22 @@
       <ValidationRegExpMessage></ValidationRegExpMessage>
       <LabelOnTop>false</LabelOnTop>
     </GenericProperty>
+    <GenericProperty>
+      <Key>33d3639f-2a8f-4a9d-9247-a574c6b47b4d</Key>
+      <Name>RegularGivingIsDefault</Name>
+      <Alias>regularGivingIsDefault</Alias>
+      <Definition>d829c2f0-96d8-4525-860e-2a824d1bf298</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="regularGiving">Regular Giving</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
   </GenericProperties>
   <Tabs>
     <Tab>

--- a/src/Giving/N3O.Umbraco.Giving/Content/Settings/DonationOptionContent.cs
+++ b/src/Giving/N3O.Umbraco.Giving/Content/Settings/DonationOptionContent.cs
@@ -32,6 +32,7 @@ namespace N3O.Umbraco.Giving.Content {
         public bool HideQuantity => GetValue(x => x.HideQuantity);
         public bool HideDonation => GetValue(x => x.HideDonation);
         public bool HideRegularGiving => GetValue(x => x.HideRegularGiving);
+        public bool RegularGivingIsDefault => GetValue(x => x.RegularGivingIsDefault);
 
         public FundDonationOptionContent Fund { get; private set; }
         public SponsorshipDonationOptionContent Sponsorship { get; private set; }

--- a/src/Giving/N3O.Umbraco.Giving/Models/DonationOption/DonationOptionMapping.cs
+++ b/src/Giving/N3O.Umbraco.Giving/Models/DonationOption/DonationOptionMapping.cs
@@ -21,6 +21,7 @@ namespace N3O.Umbraco.Giving.Models {
             dest.Dimension4 = GetFixedOrDefault(ctx, src.Dimension4, src.GetFundDimensionOptions().DefaultFundDimension4());
             dest.HideDonation = src.HideDonation;
             dest.HideRegularGiving = src.HideRegularGiving;
+            dest.RegularGivingIsDefault = src.RegularGivingIsDefault;
             dest.HideQuantity = src.HideQuantity;
 
             if (src.Type == AllocationTypes.Fund) {

--- a/src/Giving/N3O.Umbraco.Giving/Models/DonationOption/DonationOptionRes.cs
+++ b/src/Giving/N3O.Umbraco.Giving/Models/DonationOption/DonationOptionRes.cs
@@ -10,6 +10,7 @@ namespace N3O.Umbraco.Giving.Models {
         public bool HideQuantity { get; set; }
         public bool HideDonation { get; set; }
         public bool HideRegularGiving { get; set; }
+        public bool RegularGivingIsDefault { get; set; }
         public FundDonationOptionRes Fund { get; set; }
         public SponsorshipDonationOptionRes Sponsorship { get; set; }
     }


### PR DESCRIPTION
Added RegularGivingIsdefault to donation options, allows for items in donation forms to use regular as a default option.

Includes Usync import for new property in donation options doc type.