### PR TITLE
Fixed webhook import missing properties issue

### DIFF
--- a/src/Giving/N3O.Umbraco.Giving/Webhooks/DonationItemReceiver.cs
+++ b/src/Giving/N3O.Umbraco.Giving/Webhooks/DonationItemReceiver.cs
@@ -1,4 +1,3 @@
-using Humanizer;
 using N3O.Giving.Models;
 using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;

--- a/src/Giving/N3O.Umbraco.Giving/Webhooks/DonationItemReceiver.cs
+++ b/src/Giving/N3O.Umbraco.Giving/Webhooks/DonationItemReceiver.cs
@@ -1,3 +1,4 @@
+using Humanizer;
 using N3O.Giving.Models;
 using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
@@ -131,16 +132,18 @@ public class DonationItemReceiver : WebhookReceiver {
     }
 
     private IReadOnlyList<T> GetLookups<T>(IEnumerable<string> ids) where T : ILookup {
+        ids = ids.Select(x => x.RemoveWhitespace().Camelize());
+        
         return ids.OrEmpty().Select(x => _lookups.FindById<T>(x)).ExceptNull().ToList();
     }
 
     private void AddPriceRule(IContentBuilder contentBuilder, PricingRule priceRule) {
         contentBuilder.Numeric(Aliases.Price.Properties.Amount).SetDecimal(priceRule.Price?.Amount);
         contentBuilder.Toggle(Aliases.Price.Properties.Locked).Set(priceRule.Price?.Locked);
-        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension1).SetContent(_lookups.FindById<FundDimension1Value>(priceRule.Dimension1));
-        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension2).SetContent(_lookups.FindById<FundDimension2Value>(priceRule.Dimension2));
-        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension3).SetContent(_lookups.FindById<FundDimension3Value>(priceRule.Dimension3));
-        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension4).SetContent(_lookups.FindById<FundDimension4Value>(priceRule.Dimension4));
+        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension1).SetContent(_lookups.FindById<FundDimension1Value>(priceRule.Dimension1?.RemoveWhitespace().Camelize()));
+        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension2).SetContent(_lookups.FindById<FundDimension2Value>(priceRule.Dimension2?.RemoveWhitespace().Camelize()));
+        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension3).SetContent(_lookups.FindById<FundDimension3Value>(priceRule.Dimension3?.RemoveWhitespace().Camelize()));
+        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension4).SetContent(_lookups.FindById<FundDimension4Value>(priceRule.Dimension4?.RemoveWhitespace().Camelize()));
     }
     
     public class DonationItem {

--- a/src/Giving/N3O.Umbraco.Giving/Webhooks/DonationItemReceiver.cs
+++ b/src/Giving/N3O.Umbraco.Giving/Webhooks/DonationItemReceiver.cs
@@ -79,11 +79,11 @@ public class DonationItemReceiver : WebhookReceiver {
                                                     collection.Content().Key,
                                                     Aliases.DonationItem.ContentType);
         
-        var allowedGivingTypes = GetLookups<GivingType>(donationItem.AllowedGivingTypes);
-        var dimension1Options = GetLookups<FundDimension1Value>(donationItem.Dimension1Options);
-        var dimension2Options = GetLookups<FundDimension2Value>(donationItem.Dimension2Options);
-        var dimension3Options = GetLookups<FundDimension3Value>(donationItem.Dimension3Options);
-        var dimension4Options = GetLookups<FundDimension4Value>(donationItem.Dimension4Options);
+        var allowedGivingTypes = GetLookupsById<GivingType>(donationItem.AllowedGivingTypes);
+        var dimension1Options = GetLookupsByName<FundDimension1Value>(donationItem.Dimension1Options);
+        var dimension2Options = GetLookupsByName<FundDimension2Value>(donationItem.Dimension2Options);
+        var dimension3Options = GetLookupsByName<FundDimension3Value>(donationItem.Dimension3Options);
+        var dimension4Options = GetLookupsByName<FundDimension4Value>(donationItem.Dimension4Options);
 
         contentPublisher.SetName(donationItem.Name);
         contentPublisher.Content.DataList(Aliases.DonationItem.Properties.AllowedGivingTypes).SetLookups(allowedGivingTypes);
@@ -131,19 +131,21 @@ public class DonationItemReceiver : WebhookReceiver {
         }
     }
 
-    private IReadOnlyList<T> GetLookups<T>(IEnumerable<string> ids) where T : ILookup {
-        ids = ids.Select(x => x.RemoveWhitespace().Camelize());
-        
+    private IReadOnlyList<T> GetLookupsById<T>(IEnumerable<string> ids) where T : ILookup {
         return ids.OrEmpty().Select(x => _lookups.FindById<T>(x)).ExceptNull().ToList();
+    }
+    
+    private IReadOnlyList<T> GetLookupsByName<T>(IEnumerable<string> ids) where T : ILookup {
+        return ids.OrEmpty().Select(x => _lookups.FindByName<T>(x)).ExceptNull().ToList();
     }
 
     private void AddPriceRule(IContentBuilder contentBuilder, PricingRule priceRule) {
         contentBuilder.Numeric(Aliases.Price.Properties.Amount).SetDecimal(priceRule.Price?.Amount);
         contentBuilder.Toggle(Aliases.Price.Properties.Locked).Set(priceRule.Price?.Locked);
-        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension1).SetContent(_lookups.FindById<FundDimension1Value>(priceRule.Dimension1?.RemoveWhitespace().Camelize()));
-        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension2).SetContent(_lookups.FindById<FundDimension2Value>(priceRule.Dimension2?.RemoveWhitespace().Camelize()));
-        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension3).SetContent(_lookups.FindById<FundDimension3Value>(priceRule.Dimension3?.RemoveWhitespace().Camelize()));
-        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension4).SetContent(_lookups.FindById<FundDimension4Value>(priceRule.Dimension4?.RemoveWhitespace().Camelize()));
+        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension1).SetContent(_lookups.FindByName<FundDimension1Value>(priceRule.Dimension1));
+        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension2).SetContent(_lookups.FindByName<FundDimension2Value>(priceRule.Dimension2));
+        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension3).SetContent(_lookups.FindByName<FundDimension3Value>(priceRule.Dimension3));
+        contentBuilder.ContentPicker(Aliases.PricingRule.Properties.Dimension4).SetContent(_lookups.FindByName<FundDimension4Value>(priceRule.Dimension4));
     }
     
     public class DonationItem {

--- a/src/N3O.Umbraco.Extensions/Lookups/Lookup.I.cs
+++ b/src/N3O.Umbraco.Extensions/Lookups/Lookup.I.cs
@@ -4,5 +4,6 @@ namespace N3O.Umbraco.Lookups;
 
 public interface ILookup {
     string Id { get; }
+    string Name { get; }
     IEnumerable<string> GetTextValues();
 }

--- a/src/N3O.Umbraco.Extensions/Lookups/Lookup.cs
+++ b/src/N3O.Umbraco.Extensions/Lookups/Lookup.cs
@@ -12,7 +12,8 @@ public abstract class Lookup : Value, ILookup {
     }
 
     public string Id { get; }
-    
+    public string Name { get; }
+
     public virtual IEnumerable<string> GetTextValues() {
         yield return Id;
     }

--- a/src/N3O.Umbraco.Extensions/Lookups/LookupCollection.I.cs
+++ b/src/N3O.Umbraco.Extensions/Lookups/LookupCollection.I.cs
@@ -5,10 +5,12 @@ namespace N3O.Umbraco.Lookups;
 
 public interface ILookupsCollection {
     Task<ILookup> FindByIdAsync(string id);
+    public Task<ILookup> FindByNameAsync(string name);
     Task<IReadOnlyList<ILookup>> GetAllAsync();
 }
 
 public interface ILookupsCollection<T> : ILookupsCollection where T : ILookup {
     new Task<T> FindByIdAsync(string id);
+    new Task<T> FindByNameAsync(string name);
     new Task<IReadOnlyList<T>> GetAllAsync();
 }

--- a/src/N3O.Umbraco.Extensions/Lookups/LookupCollection.cs
+++ b/src/N3O.Umbraco.Extensions/Lookups/LookupCollection.cs
@@ -13,8 +13,21 @@ public abstract class LookupsCollection<T> : ILookupsCollection<T> where T : ILo
         return lookup;
     }
 
+    public virtual async Task<T> FindByNameAsync(string name) {
+        var all = await GetAllAsync();
+        var lookup = all.FirstOrDefault(x => x.Name.EqualsInvariant(name));
+
+        return lookup;
+    }
+    
     async Task<ILookup> ILookupsCollection.FindByIdAsync(string id) {
         var lookup = await FindByIdAsync(id);
+
+        return lookup;
+    }
+    
+    async Task<ILookup> ILookupsCollection.FindByNameAsync(string name) {
+        var lookup = await FindByNameAsync(name);
 
         return lookup;
     }

--- a/src/N3O.Umbraco.Extensions/Lookups/Lookups.I.cs
+++ b/src/N3O.Umbraco.Extensions/Lookups/Lookups.I.cs
@@ -11,6 +11,12 @@ public interface ILookups {
 
     Task<ILookup> FindByIdAsync(Type lookupType, string id, CancellationToken cancellationToken = default);
     ILookup FindById(Type lookupType, string id);
+    
+    Task<T> FindByNameAsync<T>(string name, CancellationToken cancellationToken = default) where T : ILookup;
+    T FindByName<T>(string name) where T : ILookup;
+
+    Task<ILookup> FindByNameAsync(Type lookupType, string name, CancellationToken cancellationToken = default);
+    ILookup FindByName(Type lookupType, string name);
 
     Task<IReadOnlyList<T>> GetAllAsync<T>(CancellationToken cancellationToken = default) where T : ILookup;
     IReadOnlyList<T> GetAll<T>() where T : ILookup;

--- a/src/N3O.Umbraco.Extensions/Lookups/Lookups.cs
+++ b/src/N3O.Umbraco.Extensions/Lookups/Lookups.cs
@@ -30,13 +30,39 @@ public class Lookups : ILookups {
 
         return result;
     }
+    
+    public async Task<T> FindByNameAsync<T>(string name, CancellationToken cancellationToken = default)
+        where T : ILookup {
+        var lookup = await FindByNameAsync(typeof(T), name, cancellationToken);
 
+        return (T) lookup;
+    }
+    
+    public async Task<ILookup> FindByNameAsync(Type lookupType,
+                                               string name,
+                                               CancellationToken cancellationToken = default) {
+        var result = await ExecuteAsync(lookupType,
+                                        lookupsCollection => lookupsCollection.FindByNameAsync(name),
+                                        null,
+                                        cancellationToken);
+        
+        return result;
+    }
+    
     public T FindById<T>(string id) where T : ILookup {
         return FindByIdAsync<T>(id).GetAwaiter().GetResult();
     }
 
     public ILookup FindById(Type lookupType, string id) {
         return FindByIdAsync(lookupType, id).GetAwaiter().GetResult();
+    }
+    
+    public T FindByName<T>(string name) where T : ILookup {
+        return FindByNameAsync<T>(name).GetAwaiter().GetResult();
+    }
+    
+    public ILookup FindByName(Type lookupType, string name) {
+        return FindByNameAsync(lookupType, name).GetAwaiter().GetResult();
     }
 
     public IReadOnlyList<T> GetAll<T>() where T : ILookup {


### PR DESCRIPTION
Some donation items received via webhook have spaces among them, e.g. "Where Most Needed". Items are searched by id, which do not have spaces and are camelized, So removed whitespaces and camelized the donation items and removed whitespaces.