### PR TITLE
Removed rounding method in price calculator

### DIFF
--- a/src/Giving/N3O.Umbraco.Giving/Services/PriceCalculator.cs
+++ b/src/Giving/N3O.Umbraco.Giving/Services/PriceCalculator.cs
@@ -47,7 +47,7 @@ public class PriceCalculator : IPriceCalculator {
                                               .ToCurrency(currency)
                                               .ConvertAsync(amountInBaseCurrency, cancellationToken);
 
-        var price = new Price(forexMoney.Quote.RoundUpToWholeNumber().Amount,
+        var price = new Price(forexMoney.Quote.Amount,
                               matchedRule?.Locked ?? pricing.Locked);
 
         return price;


### PR DESCRIPTION
Removed whole number rounding in price calculation as it returns a validation error "Invalid value specified" when trying to add a price like 19.99 to basket.