### PR TITLE
Sentry: defuse hardcoded TracesSampleRate=1.0; make it configurable

### DIFF
--- a/src/Monitoring/N3O.Umbraco.Monitoring.Sentry/Configuration/SentryConfiguration.cs
+++ b/src/Monitoring/N3O.Umbraco.Monitoring.Sentry/Configuration/SentryConfiguration.cs
@@ -2,4 +2,6 @@
 
 public class SentryConfiguration {
     public string Dsn { get; set; }
+    public double TracesSampleRate { get; set; } = 0.0;
+    public string[] TracesIgnorePaths { get; set; } = ["/health", "/live", "/ready", "/metrics"];
 }

--- a/src/Monitoring/N3O.Umbraco.Monitoring.Sentry/Hosting/SentryInitializer.cs
+++ b/src/Monitoring/N3O.Umbraco.Monitoring.Sentry/Hosting/SentryInitializer.cs
@@ -45,7 +45,19 @@ public class SentryInitializer : IHostedService {
             opt.Environment = Composer.WebHostEnvironment.EnvironmentName;
             opt.Release = EnvironmentData.GetOurValue(EnvironmentVariables.Version);
             opt.DiagnosticLevel = SentryLevel.Error;
-            opt.TracesSampleRate = 1.0f;
+            opt.TracesSampleRate = config.TracesSampleRate;
+            opt.TracesSampler = ctx => {
+                var name = ctx.TransactionContext?.Name ?? "";
+                var ignorePaths = config.TracesIgnorePaths ?? Array.Empty<string>();
+
+                foreach (var ignore in ignorePaths) {
+                    if (name.Contains(ignore, StringComparison.OrdinalIgnoreCase)) {
+                        return 0.0;
+                    }
+                }
+
+                return null;
+            };
             opt.SetBeforeSend(SentryEventRateLimiter.BeforeSend);
 
             opt.AddEventProcessorProvider(() => ResolveEventProcessors(httpContextAccessor, rootProvider));


### PR DESCRIPTION
## Summary

- `SentryConfiguration` gains `TracesSampleRate` (default `0.0`) and `TracesIgnorePaths` (default `/health, /live, /ready, /metrics`)
- `SentryInitializer` replaces the hardcoded `opt.TracesSampleRate = 1.0f` with a `TracesSampler` that returns `0.0` for transactions whose name matches an ignore path, else `null` (falls back to `TracesSampleRate`)

## Why

The hardcoded **100% transaction sampling** was a latent landmine. The `sites` Sentry project (which Umbraco targets) is currently at 0 accepted transactions over the last 30 days — apparently because Umbraco isn't in active production rotation right now — but the moment it gets re-enabled at scale, this line would burn through Sentry's transaction quota immediately and silently start dropping data.

After this PR: defaults to off. Opt in per environment via `Sentry:TracesSampleRate` in configuration. Same shape as the Karakoram.Framework PR (n3oltd/Karakoram.Framework#557).

Ignore-path defaults cover both bare (`/health`, `/live`) and `z`-suffixed (`/healthz`, `/livez`) probe endpoints via `Contains` matching — verified to match the Umbraco `app.UseHealthChecks("/healthz")` and `app.UseHealthChecks("/livez")` routes in `CmsStartup.cs`.

## Test plan

- [ ] Build the solution (`dotnet build` — done locally, 0 errors, 3 unrelated warnings)
- [ ] Smoke-test locally with `Sentry:TracesSampleRate: 0.01` in `appsettings.Development.json`:
  - [ ] `/healthz` and `/livez` transactions are dropped (not visible in Sentry)
  - [ ] Real page-load transactions appear in Sentry
- [ ] Confirm no consuming Umbraco site references the old 1.0 hardcode anywhere
- [ ] If/when Umbraco re-enters production rotation, set `Sentry--TracesSampleRate` in the relevant key vault (defaults to off → no effect until set)

## Tracking

Part of the Sentry bill-reduction plan: n3oltd/work#96

🤖 Generated with [Claude Code](https://claude.com/claude-code)