### PR TITLE
Enable Sentry in Staging + release tracking on MyGet build

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -17,5 +17,6 @@ jobs:
       run-pack: true
       version-strategy: date
       nuget-source: https://www.myget.org/F/n3o/api/v2/package
+      sentry-project: sites
     secrets:
       nuget-api-key: ${{ secrets.MYGET_API_KEY }}

--- a/src/Monitoring/N3O.Umbraco.Monitoring.Sentry/Hosting/SentryInitializer.cs
+++ b/src/Monitoring/N3O.Umbraco.Monitoring.Sentry/Hosting/SentryInitializer.cs
@@ -26,7 +26,9 @@ public class SentryInitializer : IHostedService {
     }
 
     public Task StartAsync(CancellationToken cancellationToken) {
-        if (!Composer.WebHostEnvironment.IsProduction()) {
+        var env = Composer.WebHostEnvironment;
+
+        if (!env.IsProduction() && !env.IsStaging()) {
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
## Summary

Two changes:

### 1. SentryInitializer fix

Currently skips initialisation in any environment that isn't Production:

```csharp
if (!Composer.WebHostEnvironment.IsProduction()) {
    return Task.CompletedTask;
}
```

This means sites running in **Staging** — which clients use — never report errors to Sentry. Fixed by extending the allowlist to include Staging:

```csharp
if (!env.IsProduction() && !env.IsStaging()) {
    return Task.CompletedTask;
}
```

Development and any custom env (QA, etc.) still skip init.

### 2. MyGet build creates Sentry release

`main-ci.yml` now passes `sentry-project: sites` to the shared `dotnet-build-pack-push.yml` (extended in n3oltd/actions#64). Each MyGet build creates a Sentry release `umbraco-extensions@<version>` in the `sites` project with commits attached. Side-effect: registers `n3oltd/umbraco-extensions` in Sentry's repo registry.

`tag-ci.yml` is intentionally not wired — public NuGet packages don't need Sentry tracking since only internal sites consume them, via the MyGet feed.

## Test plan

- [ ] Merge after actions#64 lands.
- [ ] Trigger a manual run of main-ci, confirm `umbraco-extensions@<version>` release lands in the `sites` Sentry project with ~10 commits attached.
- [ ] Deploy a site to staging and confirm any test error reaches Sentry tagged `environment=Staging`.