### PR TITLE
main-ci: pass SENTRY_AUTH_TOKEN through to shared workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -20,3 +20,4 @@ jobs:
       sentry-project: sites
     secrets:
       nuget-api-key: ${{ secrets.MYGET_API_KEY }}
+      sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Fix for the Main CI failure: https://github.com/n3oltd/umbraco-extensions/actions/runs/26710019237.

PR #840 enabled `sentry-project: sites`, which triggered an optional Sentry release step in the shared `dotnet-build-pack-push.yml`. That step needs `SENTRY_AUTH_TOKEN`, but the workflow's explicit `secrets:` block (for `nuget-api-key`) means GitHub does not auto-resolve `${{ secrets.SENTRY_AUTH_TOKEN }}` at workflow level. The token came through as empty string and sentry-cli failed.

This PR adds the passthrough — mirrors how `nuget-api-key` is already plumbed.

## Companion PR

n3oltd/actions#67 declares `sentry-auth-token` as an optional secret on `dotnet-build-pack-push.yml` and references it as `${{ secrets.sentry-auth-token }}` in the composite call. Both must merge.

## Test plan

- [ ] Merge n3oltd/actions#67 first.
- [ ] Merge this.
- [ ] Trigger Main CI manually (or push to main).
- [ ] Confirm the run succeeds and a `umbraco-extensions@<version>` release lands in the `sites` Sentry project with commits attached.