### PR TITLE
Tag checkout webhooks with the donor's language

### DIFF
--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.Create.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.Create.cs
@@ -3,6 +3,7 @@ using N3O.Umbraco.Entities;
 using N3O.Umbraco.Financial;
 using N3O.Umbraco.Giving.Checkout.Lookups;
 using N3O.Umbraco.Giving.Checkout.Models;
+using N3O.Umbraco.Localization;
 using N3O.Umbraco.Lookups;
 using N3O.Umbraco.References;
 using System.Net;
@@ -20,6 +21,7 @@ public partial class Checkout {
 
         checkout.CartRevisionId = cart.RevisionId;
         checkout.Reference = await counters.NextAsync<CheckoutReferenceType>();
+        checkout.Culture = LocalizationSettings.CultureCode;
         checkout.Currency = cart.Currency;
         checkout.Donation = new DonationCheckout(cart.Donation.Allocations, cart.Currency);
         checkout.RegularGiving = new RegularGivingCheckout(cart.RegularGiving.Allocations, cart.Currency);
@@ -37,11 +39,13 @@ public partial class Checkout {
                                   DonationCheckout donationCheckout,
                                   RegularGivingCheckout regularGivingCheckout,
                                   CheckoutProgress checkoutProgress,
-                                  IPAddress ipAddress) {
+                                  IPAddress ipAddress,
+                                  string culture = null) {
         var checkout = Create<Checkout>(revisionId.Id);
 
         checkout.CartRevisionId = cartRevisionId;
         checkout.Reference = reference;
+        checkout.Culture = culture;
         checkout.Currency = currency;
         checkout.Account = account;
         checkout.Donation = donationCheckout;

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.cs
@@ -18,6 +18,7 @@ public partial class Checkout : Entity, IPaymentsFlow {
     public RegularGivingCheckout RegularGiving { get; private set; }
     public IPAddress RemoteIp { get; private set; }
     public object Attribution { get; private set; }
+    public string Culture { get; private set; }
 
     public bool IsComplete => Progress.RequiredStages.All(x => x.IsComplete(this));
 }

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Webhooks/CheckoutWebhookTransform.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Webhooks/CheckoutWebhookTransform.cs
@@ -16,6 +16,7 @@ using Newtonsoft.Json.Linq;
 using NodaTime;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace N3O.Umbraco.Giving.Checkout.Webhooks;
@@ -49,8 +50,8 @@ public class CheckoutWebhookTransform : WebhookTransform {
         TransformFeedbacks(serializer, GivingTypes.RegularGiving, checkout.RegularGiving?.Allocations, jObject);
         TransformSponsorships(serializer, GivingTypes.Donation, checkout.Donation?.Allocations, jObject, checkout.Timestamp);
         TransformSponsorships(serializer, GivingTypes.RegularGiving, checkout.RegularGiving?.Allocations, jObject, checkout.Timestamp);
-        TransformTags(jObject);
-        
+        TransformTags(jObject, checkout);
+
         return jObject;
     }
 
@@ -109,13 +110,26 @@ public class CheckoutWebhookTransform : WebhookTransform {
         }
     }
     
-    private void TransformTags(JObject jObject) {
-        if (Site.Language.HasValue()) {
-            AddTag(jObject, "SiteLanguageTag", Site.Language);
+    private void TransformTags(JObject jObject, Entities.Checkout checkout) {
+        var language = (checkout.Culture.HasValue() ? GetLanguageName(checkout.Culture) : null) ?? Site.Language;
+
+        if (language.HasValue()) {
+            AddTag(jObject, "SiteLanguageTag", language);
         }
 
         if (Site.Id.HasValue()) {
             AddTag(jObject, "SiteNameTag", Site.Id);
+        }
+    }
+
+    private static string GetLanguageName(string cultureCode) {
+        try {
+            var culture = CultureInfo.GetCultureInfo(cultureCode);
+            var neutralCulture = CultureInfo.GetCultureInfo(culture.TwoLetterISOLanguageName);
+
+            return neutralCulture.EnglishName;
+        } catch (CultureNotFoundException) {
+            return null;
         }
     }
 

--- a/src/PROGRESS.md
+++ b/src/PROGRESS.md
@@ -1,0 +1,40 @@
+# Progress
+
+## Checkout webhook: tag donor's language instead of a static site env var
+
+### What
+`CheckoutWebhookTransform.TransformTags` now derives the `SiteLanguageTag` from the
+language the donor actually used for the checkout, falling back to the previous behaviour
+when unavailable.
+
+- `Checkout` entity gained a `Culture` property (the .NET culture code, e.g. `en-GB`).
+- It is captured at checkout creation (`Checkout.CreateAsync`) from
+  `LocalizationSettings.CultureCode` (the current request's thread culture). The manual
+  `Checkout.Create(...)` factory takes an optional `culture` argument.
+- The transform maps that culture code to an English language name (`en-GB` → "English",
+  `ar` → "Arabic") via the neutral culture's `EnglishName`, and falls back to
+  `Site.Language` (the `N3O_SiteLanguage` env var) when the checkout has no culture or the
+  code is unrecognised.
+
+### Why
+The previous code tagged every webhook with `Site.Language`, a single site-wide
+environment variable. On a multilingual Umbraco site (one deployment, many languages) that
+cannot represent the language an individual donor used. The correct language is only known
+during the donor's request; by the time the webhook transform runs it executes inside a
+background job with no request culture, so the value must travel with the checkout.
+
+### How it works / what we achieve
+- Culture is captured during the checkout-creating page request, where Umbraco has set the
+  thread culture from the domain/language binding — so it reflects the donor's language.
+- Stored as a plain string on the entity, it round-trips through the entity's JSON
+  persistence and survives into the cultureless background job that dispatches the webhook.
+- Result: webhooks carry the donor's actual language (e.g. "English" / "Arabic") instead of
+  a static site-wide value, while older/in-flight checkouts and unknown cultures degrade
+  gracefully to the existing env-var behaviour (no regression).
+
+### Notes
+- Name mapping uses `CultureInfo.EnglishName`, which is locale-invariant. Common languages
+  (English, Arabic) match exactly; verify the wording for any other configured languages
+  against the receiver's expectations.
+- This area is expected to be superseded by the new donation widget; the change is
+  intentionally minimal.


### PR DESCRIPTION
## What
`CheckoutWebhookTransform.TransformTags` now tags checkout webhooks with the language the **donor actually used**, instead of the static site-wide `Site.Language` env var (`N3O_SiteLanguage`).

- `Checkout` entity gains a `Culture` property (.NET culture code, e.g. `en-GB`), captured at creation (`Checkout.CreateAsync`) from `LocalizationSettings.CultureCode`.
- The manual `Checkout.Create(...)` factory takes an optional `culture` argument.
- The transform maps the culture code to an English language name (`en-GB` -> English, `ar` -> Arabic) via the neutral culture''s `EnglishName`, and falls back to `Site.Language` when the culture is missing/unrecognised.

## Why
On a multilingual Umbraco site (one deployment, many languages) a single site-wide env var cannot represent the language an individual donor used. The donor''s language is only known during their request; the webhook transform runs later inside a background job with no request culture, so the value must travel with the checkout entity.

## Behaviour / safety
- Culture is captured during the checkout-creating page request, where Umbraco has set the thread culture from the domain/language binding.
- Stored as a plain string, it round-trips through the entity''s JSON persistence and survives into the background job that dispatches the webhook.
- Older/in-flight checkouts (null culture) and unrecognised cultures fall back to the previous env-var behaviour - no regression.

## Notes
- `CultureInfo.EnglishName` is locale-invariant; English/Arabic match exactly. Verify wording for any other configured languages against the receiver''s expectations.
- This area is expected to be superseded by the new donation widget, so the change is intentionally minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)