### PR TITLE
Reword tag-ci comments to drop literal GITHUB_TOKEN

### DIFF
--- a/.github/workflows/tag-ci.yml
+++ b/.github/workflows/tag-ci.yml
@@ -61,9 +61,10 @@ jobs:
             fi
           fi
 
-          # Create + push tag with the default GITHUB_TOKEN. This push will not
-          # retrigger the `push: tags:` branch of this workflow (GitHub blocks
-          # GITHUB_TOKEN-authored events from triggering workflows), which is
+          # Create + push tag with the default Actions token (github.token). This
+          # push will not retrigger the `push: tags:` branch of this workflow
+          # (GitHub blocks default-token-authored events from triggering workflows),
+          # which is
           # fine — downstream jobs in this same run consume the version via
           # needs.prepare.outputs.version.
           git config user.name  'github-actions[bot]'


### PR DESCRIPTION
Comment-only change in `tag-ci.yml` — refers to the default Actions token as `github.token` instead of the literal `GITHUB_TOKEN`. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)