### PR TITLE
Culture-aware Typesense indexing + de-index on removal

### DIFF
--- a/src/Search/N3O.Umbraco.Search.Typesense/Handlers/IndexContentHandler.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Handlers/IndexContentHandler.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Umbraco.Extensions;
 
 namespace N3O.Umbraco.Search.Typesense.Handlers;
 
@@ -24,7 +25,13 @@ public class IndexContentHandler : IRequestHandler<IndexContentCommand, None, No
         
         if (searchIndexers.HasAny()) {
             foreach (var searchIndexer in searchIndexers) {
-                await searchIndexer.IndexAsync(publishedContent);
+                if (publishedContent.ContentType.VariesByCulture()) {
+                    foreach (var publishedContentCulture in publishedContent.Cultures) {
+                        await searchIndexer.IndexAsync(publishedContent, publishedContentCulture.Value.Culture);
+                    }
+                } else {
+                    await searchIndexer.IndexAsync(publishedContent);
+                }
             }
         }
         

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchDocumentBuilder.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchDocumentBuilder.cs
@@ -24,6 +24,7 @@ public class SearchDocumentBuilder<T> : ISearchDocumentBuilder<T> where T : clas
         var searchDocument = new T();
         
         _actions.Do(x => x(searchDocument));
+        _actions.Clear();
 
         return TransformObject(searchDocument);
     }

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.I.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.I.cs
@@ -6,5 +6,5 @@ namespace N3O.Umbraco.Search.Typesense;
 public interface ISearchIndexer {
     bool CanIndex(IPublishedContent content);
     Task DeleteAsync(string id);
-    Task IndexAsync(IPublishedContent content);
+    Task IndexAsync(IPublishedContent content, string culture = null);
 }

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.cs
@@ -25,8 +25,8 @@ public abstract class SearchIndexer<TContent, TDocument> : ISearchIndexer
         await _typesenseClient.DeleteDocument<TDocument>(collectionInfo.Name.Resolve(), id);
     }
 
-    public async Task IndexAsync(IPublishedContent content) {
-        await ProcessContentAsync(_searchDocumentBuilder, (TContent) content);
+    public async Task IndexAsync(IPublishedContent content, string culture = null) {
+        await ProcessContentAsync(_searchDocumentBuilder, (TContent) content, culture);
 
         var document = _searchDocumentBuilder.Build();
         var collectionInfo = TypesenseHelper.GetCollection<TDocument>();
@@ -34,5 +34,7 @@ public abstract class SearchIndexer<TContent, TDocument> : ISearchIndexer
         await _typesenseClient.UpsertDocument(collectionInfo.Name.Resolve(), document);
     }
 
-    protected abstract Task ProcessContentAsync(ISearchDocumentBuilder<TDocument> builder, TContent content);
+    protected abstract Task ProcessContentAsync(ISearchDocumentBuilder<TDocument> builder,
+                                                TContent content,
+                                                string culture = null);
 }

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.cs
@@ -36,5 +36,5 @@ public abstract class SearchIndexer<TContent, TDocument> : ISearchIndexer
 
     protected abstract Task ProcessContentAsync(ISearchDocumentBuilder<TDocument> builder,
                                                 TContent content,
-                                                string culture = null);
+                                                string culture);
 }


### PR DESCRIPTION
Makes the Typesense search indexer culture-aware so multilingual content is indexed per published culture, and adds the missing de-indexing path on unpublish/delete.

re n3oltd/work#2626

## Summary

- Index each published culture as its own Typesense document — composite id `{contentKey}_{culture}` plus `content_key`/`culture` fields on `SearchDocument`.
- Framework owns the culture mechanics: id generation (`SearchDocument.GetId`), `ContentKey`/`Culture` assignment, and the ambient `VariationContext` — consuming indexers just describe document fields.
- Remove a node's documents on unpublish / move-to-recycle-bin / delete via a filtered delete on `content_key` (all culture variants in one call) — previously there was no de-indexing path at all.
- Skip enqueue/processing for content types no indexer owns (`CanIndex(alias)`), so no useless background jobs.
- Tighten generic constraints to `SearchDocument`, reset the document builder between cultures, and guard against an unconfigured Typesense client.

## Release notes

Search now indexes each published language of a page as its own result, and removes pages from search when they are unpublished or deleted.

## Notes

- Binary-breaking for consumers (`ISearchIndexer`/`SearchIndexer` signatures, `SearchDocument.Id` type) — needs a coordinated package publish plus the consuming-site indexer updates (done in `MuslimHands.Website`, where the Pages/HelpDesk collections are re-versioned to pick up the new schema).
