### PR TITLE
Remove unused culture parameter from ProcessContentAsync

### DIFF
--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.cs
@@ -53,7 +53,7 @@ public abstract class SearchIndexer<TContent, TDocument> : ISearchIndexer
             _variationContextAccessor.VariationContext = new VariationContext(culture);
         }
 
-        await ProcessContentAsync(_searchDocumentBuilder, (TContent) content, culture);
+        await ProcessContentAsync(_searchDocumentBuilder, (TContent) content);
 
         _searchDocumentBuilder.Set(searchDocument => {
             searchDocument.ContentKey = content.Key;
@@ -67,7 +67,5 @@ public abstract class SearchIndexer<TContent, TDocument> : ISearchIndexer
         await _typesenseClient.UpsertDocument(collectionInfo.Name.Resolve(), document);
     }
 
-    protected abstract Task ProcessContentAsync(ISearchDocumentBuilder<TDocument> builder,
-                                                TContent content,
-                                                string culture);
+    protected abstract Task ProcessContentAsync(ISearchDocumentBuilder<TDocument> builder, TContent content);
 }


### PR DESCRIPTION
Removes the now-unused `culture` parameter from the abstract `ProcessContentAsync`.

re n3oltd/work#2626

The framework sets the ambient `VariationContext` from `culture` before calling `ProcessContentAsync` (and uses it for the document id), so consuming indexers no longer read `culture` directly — every culture-aware read (`Value`, `Name`, `Url`, blocks) resolves from the context. Dropping the parameter removes the one culture argument a consumer could forget.

`IndexAsync` keeps `culture`; only the abstract hook signature and its single call site change.

## Notes

Binary-breaking for consumers (the `ProcessContentAsync` override signature) — the Muslim Hands site indexers drop the parameter to match (n3oltd/site-mh).
