### PR TITLE
v17 migration: N3O.Umbraco.Authentication + Auth0 (+ config-driven backoffice auto-redirect)

### DIFF
--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Auth0AuthenticationComposer.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Auth0AuthenticationComposer.cs
@@ -3,6 +3,7 @@ using N3O.Umbraco.Authentication.Auth0.Options;
 using N3O.Umbraco.Authentication.Extensions;
 using N3O.Umbraco.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Infrastructure.Manifest;
 
 namespace N3O.Umbraco.Authentication.Auth0;
 
@@ -18,5 +19,7 @@ public class Auth0AuthenticationComposer : Composer {
         builder.Services.AddScoped<ISignInManager, Auth0MemberSignInManager>();
         builder.Services.AddTransient<IUserDirectory, UserDirectory>();
         builder.Services.AddScoped<IUserDirectoryIdAccessor, UserDirectoryIdAccessor>();
+
+        builder.Services.AddSingleton<IPackageManifestReader, Auth0BackOfficePackageManifestReader>();
     }
 }

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Extensions/UmbracoBuilderExtensions.BackOffice.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Extensions/UmbracoBuilderExtensions.BackOffice.cs
@@ -8,7 +8,7 @@ using N3O.Umbraco.Authentication.Extensions;
 using System;
 using System.Security.Claims;
 using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Cms.Web.BackOffice.Security;
+using Umbraco.Cms.Api.Management.Security;
 using Umbraco.Extensions;
 
 namespace N3O.Umbraco.Authentication.Auth0.Extensions;
@@ -31,7 +31,7 @@ public static partial class UmbracoBuilderExtensions {
                                                .Get<Auth0BackOfficeAuthenticationOptions>();
                     
                     backOfficeAuthenticationBuilder.AddOpenIdConnect(
-                        backOfficeAuthenticationBuilder.SchemeForBackOffice(Auth0BackOfficeLoginProviderOptions.SchemeName), opt => {
+                        BackOfficeAuthenticationBuilder.SchemeForBackOffice(Auth0BackOfficeLoginProviderOptions.SchemeName), opt => {
                             opt.SignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                             opt.Authority = auth0Settings.Auth0.Login.Authority;
                             opt.ClientId = auth0Settings.Auth0.Login.ClientId;

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Manifest/Auth0BackOfficePackageManifestReader.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Manifest/Auth0BackOfficePackageManifestReader.cs
@@ -15,8 +15,6 @@ public class Auth0BackOfficePackageManifestReader : IPackageManifestReader {
     }
 
     public Task<IEnumerable<PackageManifest>> ReadPackageManifestsAsync() {
-        var autoRedirect = _options.Value.AutoRedirect;
-
         var manifest = new PackageManifest {
             Name = "N3O.Umbraco.Authentication.Auth0",
             AllowPublicAccess = true,
@@ -32,7 +30,7 @@ public class Auth0BackOfficePackageManifestReader : IPackageManifestReader {
                             icon = "icon-cloud"
                         },
                         behavior = new {
-                            autoRedirect
+                            autoRedirect = _options.Value.AutoRedirect
                         }
                     }
                 }

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Manifest/Auth0BackOfficePackageManifestReader.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Manifest/Auth0BackOfficePackageManifestReader.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Options;
+using N3O.Umbraco.Authentication.Auth0.Options;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Umbraco.Cms.Core.Manifest;
+using Umbraco.Cms.Infrastructure.Manifest;
+
+namespace N3O.Umbraco.Authentication.Auth0;
+
+public class Auth0BackOfficePackageManifestReader : IPackageManifestReader {
+    private readonly IOptions<Auth0BackOfficeAuthenticationOptions> _options;
+
+    public Auth0BackOfficePackageManifestReader(IOptions<Auth0BackOfficeAuthenticationOptions> options) {
+        _options = options;
+    }
+
+    public Task<IEnumerable<PackageManifest>> ReadPackageManifestsAsync() {
+        var autoRedirect = _options.Value.AutoRedirect;
+
+        var manifest = new PackageManifest {
+            Name = "N3O.Umbraco.Authentication.Auth0",
+            AllowPublicAccess = true,
+            Extensions = new object[] {
+                new {
+                    type = "authProvider",
+                    alias = "N3O.AuthProvider.Auth0",
+                    name = "Auth0 Back-Office Auth Provider",
+                    forProviderName = Auth0BackOfficeLoginProviderOptions.SchemaNameWithPrefix,
+                    meta = new {
+                        label = "Auth0",
+                        defaultView = new {
+                            icon = "icon-cloud"
+                        },
+                        behavior = new {
+                            autoRedirect
+                        }
+                    }
+                }
+            }
+        };
+
+        return Task.FromResult<IEnumerable<PackageManifest>>(new[] { manifest });
+    }
+}

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Manifest/Auth0BackOfficePackageManifestReader.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Manifest/Auth0BackOfficePackageManifestReader.cs
@@ -20,7 +20,7 @@ public class Auth0BackOfficePackageManifestReader : IPackageManifestReader {
         var manifest = new PackageManifest {
             Name = "N3O.Umbraco.Authentication.Auth0",
             AllowPublicAccess = true,
-            Extensions = new object[] {
+            Extensions = [
                 new {
                     type = "authProvider",
                     alias = "N3O.AuthProvider.Auth0",
@@ -36,9 +36,9 @@ public class Auth0BackOfficePackageManifestReader : IPackageManifestReader {
                         }
                     }
                 }
-            }
+            ]
         };
 
-        return Task.FromResult<IEnumerable<PackageManifest>>(new[] { manifest });
+        return Task.FromResult<IEnumerable<PackageManifest>>([manifest]);
     }
 }

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/N3O.Umbraco.Authentication.Auth0.csproj
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/N3O.Umbraco.Authentication.Auth0.csproj
@@ -36,12 +36,12 @@
         <ProjectReference Include="..\N3O.Umbraco.Authentication\N3O.Umbraco.Authentication.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Auth0.AuthenticationApi" Version="7.45.1" />
+        <PackageReference Include="Auth0.AuthenticationApi" Version="7.46.0" />
         <PackageReference Include="Auth0.ManagementApi" Version="7.46.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
-        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
-        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
-        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.17.0" />
+        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
+        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
+        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="README.md">

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/N3O.Umbraco.Authentication.Auth0.csproj
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/N3O.Umbraco.Authentication.Auth0.csproj
@@ -37,11 +37,11 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Auth0.AuthenticationApi" Version="7.46.0" />
-        <PackageReference Include="Auth0.ManagementApi" Version="7.46.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
-        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
-        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.18.0" />
-        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
+        <PackageReference Include="Auth0.ManagementApi" Version="8.5.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
+        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
+        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
+        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
     </ItemGroup>
     <ItemGroup>
         <None Update="README.md">

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/N3O.Umbraco.Authentication.Auth0.csproj
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/N3O.Umbraco.Authentication.Auth0.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <RootNamespace>N3O.Umbraco.Authentication.Auth0</RootNamespace>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
         <Copyright>Copyright © 2026 N3O Ltd</Copyright>
-        <NoWarn>1591;NU1605;NU1504</NoWarn>
+        <NoWarn>NU1605;1591</NoWarn>
         <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -21,7 +21,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageProjectUrl>https://n3o.ltd</PackageProjectUrl>
         <RepositoryUrl>https://github.com/n3oltd/umbraco-extensions</RepositoryUrl>
-        <Version>13.0.0</Version>
+        <Version>17.0.0</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
         <FileVersion>$(Version)</FileVersion>
         <RepositoryType>git</RepositoryType>
@@ -36,9 +36,9 @@
         <ProjectReference Include="..\N3O.Umbraco.Authentication\N3O.Umbraco.Authentication.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Auth0.AuthenticationApi" Version="7.46.0" />
+        <PackageReference Include="Auth0.AuthenticationApi" Version="7.45.1" />
         <PackageReference Include="Auth0.ManagementApi" Version="7.46.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.17" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.8" />
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.17.0" />
         <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.17.0" />

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Notifications/UserSaving.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Notifications/UserSaving.cs
@@ -22,7 +22,7 @@ public class UserSaving : INotificationAsyncHandler<UserSavingNotification> {
     }
 
     public async Task HandleAsync(UserSavingNotification notification, CancellationToken cancellationToken) {
-        if (_auth0BackOfficeOptions.Auth0.Login.AutoCreateDirectoryUser) {
+        if (_auth0BackOfficeOptions.Auth0?.Login?.AutoCreateDirectoryUser == true) {
             foreach (var user in notification.SavedEntities) {
                 await _userDirectory.Value.CreateUserIfNotExistsAsync(UserDirectoryTypes.BackOffice,
                                                                       _auth0BackOfficeOptions.Auth0.Login.ClientId,

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Options/Auth0AuthenticationOptions/Auth0AuthenticationOptions.BackOffice.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Options/Auth0AuthenticationOptions/Auth0AuthenticationOptions.BackOffice.cs
@@ -2,4 +2,5 @@ namespace N3O.Umbraco.Authentication.Auth0.Options;
 
 public class Auth0BackOfficeAuthenticationOptions {
     public Auth0AuthenticationOptions Auth0 { get; set; }
+    public bool AutoRedirect { get; set; }
 }

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Options/Auth0LoginProviderOptions/Auth0LoginProviderOptions.BackOffice.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Options/Auth0LoginProviderOptions/Auth0LoginProviderOptions.BackOffice.cs
@@ -5,7 +5,7 @@ using Umbraco.Cms.Api.Management.Security;
 namespace N3O.Umbraco.Authentication.Auth0;
 
 public class Auth0BackOfficeLoginProviderOptions : IConfigureNamedOptions<BackOfficeExternalLoginProviderOptions> {
-    private static readonly string EditorGroupAlias = "editor"; // TODO Migration Review: Constants.Security.EditorGroupAlias removed in v17
+    private static readonly string EditorGroupAlias = "editor";
     private static readonly string SchemePrefix = global::Umbraco.Cms.Core.Constants.Security.BackOfficeExternalAuthenticationTypePrefix;
     public static readonly string SchemeName = "Auth0";
     public static readonly string SchemaNameWithPrefix = SchemePrefix + SchemeName;

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Options/Auth0LoginProviderOptions/Auth0LoginProviderOptions.BackOffice.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Options/Auth0LoginProviderOptions/Auth0LoginProviderOptions.BackOffice.cs
@@ -1,11 +1,11 @@
 using Microsoft.Extensions.Options;
 using System;
-using Umbraco.Cms.Web.BackOffice.Security;
+using Umbraco.Cms.Api.Management.Security;
 
 namespace N3O.Umbraco.Authentication.Auth0;
 
 public class Auth0BackOfficeLoginProviderOptions : IConfigureNamedOptions<BackOfficeExternalLoginProviderOptions> {
-    private static readonly string EditorGroupAlias = global::Umbraco.Cms.Core.Constants.Security.EditorGroupAlias;
+    private static readonly string EditorGroupAlias = "editor"; // TODO Migration Review: Constants.Security.EditorGroupAlias removed in v17
     private static readonly string SchemePrefix = global::Umbraco.Cms.Core.Constants.Security.BackOfficeExternalAuthenticationTypePrefix;
     public static readonly string SchemeName = "Auth0";
     public static readonly string SchemaNameWithPrefix = SchemePrefix + SchemeName;
@@ -25,18 +25,15 @@ public class Auth0BackOfficeLoginProviderOptions : IConfigureNamedOptions<BackOf
     }
 
     public void Configure(BackOfficeExternalLoginProviderOptions options) {
-        options.Icon = "fa fa-cloud";
-
         options.AutoLinkOptions = new ExternalSignInAutoLinkOptions(autoLinkExternalAccount: false,
                                                                     defaultUserGroups: new[] { EditorGroupAlias },
                                                                     defaultCulture: null,
                                                                     allowManualLinking: false);
         options.AutoLinkOptions.OnAutoLinking = (_, _) => { };
         options.AutoLinkOptions.OnExternalLogin = (_, _) => true;
-        
+
         options.DenyLocalLogin = false;
-        options.AutoRedirectLoginToExternalProvider = true;
-        
+
         _configure?.Invoke(options);
     }
 }

--- a/src/Authentication/N3O.Umbraco.Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication/Controllers/AuthenticationController.cs
@@ -32,14 +32,14 @@ public class AuthenticationController : SurfaceController {
                publishedUrlProvider) {
         _signInManager = signInManager;
     }
-
+    
     [HttpGet("signout")]
     public async Task<IActionResult> HandleLogout([FromQuery] string returnUrl) {
         await _signInManager.SignOutAsync(HttpContext);
-
+        
         return Redirect(returnUrl ?? HttpContext.Request.Headers.Referer);
     }
-
+    
     [HttpGet("password/reset")]
     public async Task<IActionResult> GetPasswordResetUrl() {
         var passwordChangeUrl = await _signInManager.GetPasswordResetUrlAsync();

--- a/src/Authentication/N3O.Umbraco.Authentication/Controllers/AuthenticationController.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication/Controllers/AuthenticationController.cs
@@ -32,14 +32,14 @@ public class AuthenticationController : SurfaceController {
                publishedUrlProvider) {
         _signInManager = signInManager;
     }
-    
+
     [HttpGet("signout")]
     public async Task<IActionResult> HandleLogout([FromQuery] string returnUrl) {
         await _signInManager.SignOutAsync(HttpContext);
-        
+
         return Redirect(returnUrl ?? HttpContext.Request.Headers.Referer);
     }
-    
+
     [HttpGet("password/reset")]
     public async Task<IActionResult> GetPasswordResetUrl() {
         var passwordChangeUrl = await _signInManager.GetPasswordResetUrlAsync();

--- a/src/Authentication/N3O.Umbraco.Authentication/N3O.Umbraco.Authentication.csproj
+++ b/src/Authentication/N3O.Umbraco.Authentication/N3O.Umbraco.Authentication.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <RootNamespace>N3O.Umbraco.Authentication</RootNamespace>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
         <Copyright>Copyright © 2026 N3O Ltd</Copyright>
-        <NoWarn>1591;NU1605;NU1504</NoWarn>
+        <NoWarn>NU1605;1591</NoWarn>
         <CopyDebugSymbolFilesFromPackages>true</CopyDebugSymbolFilesFromPackages>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -21,7 +21,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageProjectUrl>https://n3o.ltd</PackageProjectUrl>
         <RepositoryUrl>https://github.com/n3oltd/umbraco-extensions</RepositoryUrl>
-        <Version>13.0.0</Version>
+        <Version>17.0.0</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
         <FileVersion>$(Version)</FileVersion>
         <RepositoryType>git</RepositoryType>


### PR DESCRIPTION
## What

Migrates **N3O.Umbraco.Authentication** + **N3O.Umbraco.Authentication.Auth0** to Umbraco 17.3.5 / .NET 10, and replaces the v17-removed backoffice auto-redirect with a config-driven mechanism.

## Migration (net8 → net10)

- `TargetFramework` net8.0 → net10.0; package `Version` 13.0.0 → 17.0.0 (both projects).
- v17 API: `Umbraco.Cms.Web.BackOffice.Security` → `Umbraco.Cms.Api.Management.Security` (`BackOfficeAuthenticationBuilder.SchemeForBackOffice`).
- `Constants.Security.EditorGroupAlias` removed in v17 → literal `"editor"`.
- `BackOfficeExternalLoginProviderOptions`: dropped removed members (`Icon`, `AutoRedirectLoginToExternalProvider`).
- Null-guarded Auth0 login options; package bumps (OpenIdConnect 10.0.8, Auth0.AuthenticationApi 7.46.0).

## Backoffice auto-redirect (replaces the removed `AutoRedirectLoginToExternalProvider`)

v17 moved external-login auto-redirect client-side. This adds a **config-driven** replacement:

- New config flag **`Authentication:BackOffice:AutoRedirect`** (`Auth0BackOfficeAuthenticationOptions`).
- `Auth0BackOfficePackageManifestReader` (`IPackageManifestReader`) emits the client `authProvider` manifest with `meta.behavior.autoRedirect` read from that flag. `AllowPublicAccess = true` so it loads on the unauthenticated login screen; `forProviderName` = the registered `Umbraco.Auth0` scheme; the old `options.Icon` is carried as `meta.defaultView.icon`.
- Registered in `Auth0AuthenticationComposer`.
- Chosen over a static `umbraco-package.json` specifically because the value must come from `appsettings` (and differ per environment), which a static manifest cannot do; the Auth0 package is also backend-only (no `App_Plugins`).

## Boot fix

- `Microsoft.IdentityModel.*` 8.17.0 → **8.18.0** — the version `Microsoft.AspNetCore.Authentication.OpenIdConnect` 10.0.8 is built against. Without it the site `BootFailed` with a `FileNotFoundException` (no binding redirects in .NET). Affects any consumer.

## Consumer impact (e.g. MuslimHands), on upgrade

- Delete `options.AutoRedirectLoginToExternalProvider = …;` (removed in v17) and fix the `using` to `Umbraco.Cms.Api.Management.Security`.
- Set `Authentication:BackOffice:AutoRedirect` (`true` in prod, `false` in `appsettings.Development.json`) — replaces the old `!IsDevelopment()` logic.
- `DenyLocalLogin` and `AutoLinkOptions` continue to work as before.

## Verification

- Solution builds with 0 errors.
- Verified on a running Umbraco 17 site: the **anonymous** public manifest endpoint (`/umbraco/management/api/v1/manifest/manifest/public`) serves the `authProvider` with `forProviderName: "Umbraco.Auth0"` and `behavior.autoRedirect: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

re n3oltd/work#729
