### PR TITLE
fix(scheduler): honour 30 minute JobTrigger timeout

### DIFF
--- a/src/Scheduler/N3O.Umbraco.Scheduler/Services/JobTrigger.cs
+++ b/src/Scheduler/N3O.Umbraco.Scheduler/Services/JobTrigger.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace N3O.Umbraco.Scheduler;
@@ -30,29 +29,27 @@ public class JobTrigger {
                                    string modelJson,
                                    IReadOnlyDictionary<string, string> parameterData) {
         var httpClient = _httpClientFactory.CreateClient();
-        httpClient.Timeout = Timeout.InfiniteTimeSpan;
+        httpClient.Timeout = TimeSpan.FromMinutes(30);
         var req = GetProxyReq(triggerKey, modelJson, parameterData);
         var url = GetUrl();
         var reqStr = _jsonProvider.SerializeObject(req);
 
-        using (var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(30))) {
-            var request = new HttpRequestMessage(HttpMethod.Post, url);
-            request.Content = new StringContent(reqStr, null, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Post, url);
+        request.Content = new StringContent(reqStr, null, "application/json");
 
-            request.Headers.Add("accept", "*/*");
-            request.Headers.Add("X-Api-Key", TriggerKey.ApiSecurityKey);
+        request.Headers.Add("accept", "*/*");
+        request.Headers.Add("X-Api-Key", TriggerKey.ApiSecurityKey);
 
-            if (parameterData?.ContainsKey(SchedulerConstants.Parameters.Culture) == true) {
-                request.Headers.Add("Accept-Language", parameterData[SchedulerConstants.Parameters.Culture]);
-            }
+        if (parameterData?.ContainsKey(SchedulerConstants.Parameters.Culture) == true) {
+            request.Headers.Add("Accept-Language", parameterData[SchedulerConstants.Parameters.Culture]);
+        }
 
-            var response = await httpClient.SendAsync(request, timeout.Token);
+        var response = await httpClient.SendAsync(request);
 
-            if (!response.IsSuccessStatusCode) {
-                var content = await response.Content.ReadAsStringAsync(timeout.Token);
+        if (!response.IsSuccessStatusCode) {
+            var content = await response.Content.ReadAsStringAsync();
 
-                throw new Exception(content);
-            }
+            throw new Exception(content);
         }
     }
 

--- a/src/Scheduler/N3O.Umbraco.Scheduler/Services/JobTrigger.cs
+++ b/src/Scheduler/N3O.Umbraco.Scheduler/Services/JobTrigger.cs
@@ -30,6 +30,7 @@ public class JobTrigger {
                                    string modelJson,
                                    IReadOnlyDictionary<string, string> parameterData) {
         var httpClient = _httpClientFactory.CreateClient();
+        httpClient.Timeout = Timeout.InfiniteTimeSpan;
         var req = GetProxyReq(triggerKey, modelJson, parameterData);
         var url = GetUrl();
         var reqStr = _jsonProvider.SerializeObject(req);


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2692

## Summary

`JobTrigger.TriggerAsync` creates a 30 minute `CancellationTokenSource` to bound the self-call to `/umbraco/api/JobProxy/executeProxied` and passes its token to `SendAsync`, but it never sets `HttpClient.Timeout`. The client therefore keeps its default 100s timeout, which always fires before the 30 minute token — producing the misleading `"The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing"` exception and leaving the 30 minute token as dead code.

This sets `HttpClient.Timeout` to a finite 30 minutes (the value the dead token already intended) and drops the now-redundant `CancellationTokenSource`. A finite timeout, rather than `Timeout.InfiniteTimeSpan`, ensures a hung self-call can never block the single Hangfire worker (`WorkerCount = 1`) forever.

## Test plan

- [ ] A proxied job whose handler runs longer than 100s no longer fails with the 100s `HttpClient.Timeout` exception
- [ ] A job that genuinely hangs is cancelled after 30 minutes rather than blocking the worker indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)
