### PR TITLE
Overridable ICurrencyRounder + ceiling rounding for converted currency — work#2642

### DIFF
--- a/src/Forex/N3O.Umbraco.Forex/Models/CurrencyValuesMapping.cs
+++ b/src/Forex/N3O.Umbraco.Forex/Models/CurrencyValuesMapping.cs
@@ -10,10 +10,12 @@ namespace N3O.Umbraco.Forex.Models;
 public class CurrencyValuesMapping : IMapDefinition {
     private readonly ILookups _lookups;
     private readonly IForexConverter _forexConverter;
+    private readonly ICurrencyRounder _currencyRounder;
 
-    public CurrencyValuesMapping(ILookups lookups, IForexConverter forexConverter) {
+    public CurrencyValuesMapping(ILookups lookups, IForexConverter forexConverter, ICurrencyRounder currencyRounder) {
         _lookups = lookups;
         _forexConverter = forexConverter;
+        _currencyRounder = currencyRounder;
     }
     
     public void DefineMaps(IUmbracoMapper mapper) {
@@ -30,8 +32,8 @@ public class CurrencyValuesMapping : IMapDefinition {
 
         foreach (var currency in otherCurrencies) {
             var forexMoney = _forexConverter.BaseToQuote().ToCurrency(currency).Convert(src);
-            
-            dest[currency.Code] = ctx.Map<Money, MoneyRes>(forexMoney.Quote);
+
+            dest[currency.Code] = ctx.Map<Money, MoneyRes>(_currencyRounder.Round(forexMoney.Quote));
         }
     }
 }

--- a/src/Giving/N3O.Umbraco.Giving.Allocations/Extensions/UpsellOfferContentExtensions.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Allocations/Extensions/UpsellOfferContentExtensions.cs
@@ -17,6 +17,7 @@ public static class UpsellOfferContentExtensions {
                                                            IForexConverter forexConverter,
                                                            IPriceCalculator priceCalculator,
                                                            ILookups lookups,
+                                                           ICurrencyRounder currencyRounder,
                                                            Currency currency,
                                                            decimal? customAmount,
                                                            GivingType givingType,
@@ -28,6 +29,7 @@ public static class UpsellOfferContentExtensions {
         var amount = await CalculatePriceAsync(forexConverter,
                                                priceCalculator,
                                                lookups,
+                                               currencyRounder,
                                                upsellOfferContent,
                                                currency,
                                                givingType,
@@ -53,6 +55,7 @@ public static class UpsellOfferContentExtensions {
                                                              IForexConverter forexConverter,
                                                              IPriceCalculator priceCalculator,
                                                              ILookups lookups,
+                                                             ICurrencyRounder currencyRounder,
                                                              Currency currency,
                                                              GivingType givingType,
                                                              Money cartTotal) {
@@ -63,6 +66,7 @@ public static class UpsellOfferContentExtensions {
         var price = await CalculatePriceAsync(forexConverter,
                                               priceCalculator,
                                               lookups,
+                                              currencyRounder,
                                               upsellOfferContent,
                                               currency,
                                               givingType,
@@ -81,6 +85,7 @@ public static class UpsellOfferContentExtensions {
     private static async Task<Money> CalculatePriceAsync(IForexConverter forexConverter,
                                                          IPriceCalculator priceCalculator,
                                                          ILookups lookups,
+                                                         ICurrencyRounder currencyRounder,
                                                          UpsellOfferContent upsellOfferContent,
                                                          Currency currency,
                                                          GivingType givingType,
@@ -98,6 +103,10 @@ public static class UpsellOfferContentExtensions {
                                          .ConvertAsync(upsellOfferContent.FixedAmount.GetValueOrThrow())).Quote;
         } else if (!upsellOfferContent.PriceHandles.HasAny()) {
             price = GetCustomPrice(forexConverter, upsellOfferContent, currency, givingType, cartTotal);
+        }
+
+        if (price != null && !currency.IsBaseCurrency) {
+            price = currencyRounder.Round(price);
         }
 
         return price;

--- a/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.Add.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.Add.cs
@@ -1,5 +1,6 @@
 using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Financial;
 using N3O.Umbraco.Forex;
 using N3O.Umbraco.Giving.Allocations;
 using N3O.Umbraco.Giving.Allocations.Lookups;
@@ -16,6 +17,7 @@ public partial class Cart {
                                IForexConverter forexConverter,
                                IPriceCalculator priceCalculator,
                                ILookups lookups,
+                               ICurrencyRounder currencyRounder,
                                GivingType givingType,
                                IAllocation allocation,
                                int quantity = 1) {
@@ -24,6 +26,7 @@ public partial class Cart {
                                        forexConverter,
                                        priceCalculator,
                                        lookups,
+                                       currencyRounder,
                                        givingType,
                                        c => AddToContents(c, allocation));
 

--- a/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.BulkRemove.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.BulkRemove.cs
@@ -1,4 +1,5 @@
 ﻿using N3O.Umbraco.Content;
+using N3O.Umbraco.Financial;
 using N3O.Umbraco.Forex;
 using N3O.Umbraco.Giving.Allocations;
 using N3O.Umbraco.Giving.Allocations.Lookups;
@@ -16,12 +17,14 @@ public partial class Cart {
                                       IForexConverter forexConverter,
                                       IPriceCalculator priceCalculator,
                                       ILookups lookups,
+                                      ICurrencyRounder currencyRounder,
                                       GivingType givingType,
                                       IEnumerable<int> allocationIndexes) {
         await ReplaceContentsAsync(contentLocator,
                                    forexConverter,
                                    priceCalculator,
                                    lookups,
+                                   currencyRounder,
                                    givingType,
                                    c => BulkRemoveContents(c, allocationIndexes.ToList()));
     }

--- a/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.Remove.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.Remove.cs
@@ -1,4 +1,5 @@
 using N3O.Umbraco.Content;
+using N3O.Umbraco.Financial;
 using N3O.Umbraco.Forex;
 using N3O.Umbraco.Giving.Allocations;
 using N3O.Umbraco.Giving.Allocations.Lookups;
@@ -15,12 +16,14 @@ public partial class Cart {
                                   IForexConverter forexConverter,
                                   IPriceCalculator priceCalculator,
                                   ILookups lookups,
+                                  ICurrencyRounder currencyRounder,
                                   GivingType givingType,
                                   int allocationIndex) {
         await ReplaceContentsAsync(contentLocator,
                                    forexConverter,
                                    priceCalculator,
                                    lookups,
+                                   currencyRounder,
                                    givingType,
                                    c => RemoveContents(c, allocationIndex));
     }

--- a/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.RemoveAll.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.RemoveAll.cs
@@ -1,4 +1,5 @@
 using N3O.Umbraco.Content;
+using N3O.Umbraco.Financial;
 using N3O.Umbraco.Forex;
 using N3O.Umbraco.Giving.Allocations;
 using N3O.Umbraco.Giving.Allocations.Lookups;
@@ -13,11 +14,13 @@ public partial class Cart {
                                      IForexConverter forexConverter,
                                      IPriceCalculator priceCalculator,
                                      ILookups lookups,
+                                     ICurrencyRounder currencyRounder,
                                      GivingType givingType) {
         await ReplaceContentsAsync(contentLocator,
                                    forexConverter,
                                    priceCalculator,
                                    lookups,
+                                   currencyRounder,
                                    givingType,
                                    _ => CartContents.Create(Currency, givingType));
     }

--- a/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.RemoveUpsell.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.RemoveUpsell.cs
@@ -1,5 +1,6 @@
 using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Financial;
 using N3O.Umbraco.Forex;
 using N3O.Umbraco.Giving.Allocations;
 using N3O.Umbraco.Giving.Allocations.Lookups;
@@ -16,12 +17,14 @@ public partial class Cart {
                                         IForexConverter forexConverter,
                                         IPriceCalculator priceCalculator,
                                         ILookups lookups,
+                                        ICurrencyRounder currencyRounder,
                                         GivingType givingType,
                                         Guid upsellOfferId) {
         await ReplaceContentsAsync(contentLocator,
                                    forexConverter,
                                    priceCalculator,
                                    lookups,
+                                   currencyRounder,
                                    givingType,
                                    c => RemoveUpsellByOfferId(c, upsellOfferId));
     }

--- a/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.ReplaceContents.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Cart/Entities/Cart/Cart.ReplaceContents.cs
@@ -1,6 +1,7 @@
 using N3O.Umbraco.Content;
 using N3O.Umbraco.Exceptions;
 using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Financial;
 using N3O.Umbraco.Forex;
 using N3O.Umbraco.Giving.Allocations;
 using N3O.Umbraco.Giving.Allocations.Content;
@@ -20,6 +21,7 @@ public partial class Cart {
                                             IForexConverter forexConverter,
                                             IPriceCalculator priceCalculator,
                                             ILookups lookups,
+                                            ICurrencyRounder currencyRounder,
                                             GivingType givingType,
                                             Func<CartContents, CartContents> replace) {
         if (givingType == GivingTypes.Donation) {
@@ -27,12 +29,14 @@ public partial class Cart {
                                                       forexConverter,
                                                       priceCalculator,
                                                       lookups,
+                                                      currencyRounder,
                                                       replace(Donation));
         } else if (givingType == GivingTypes.RegularGiving) {
             RegularGiving = await UpdateUpsellAmountsAsync(contentLocator,
                                                            forexConverter,
                                                            priceCalculator,
                                                            lookups,
+                                                           currencyRounder,
                                                            replace(RegularGiving));
         } else {
             throw UnrecognisedValueException.For(givingType);
@@ -43,6 +47,7 @@ public partial class Cart {
                                                               IForexConverter forexConverter,
                                                               IPriceCalculator priceCalculator,
                                                               ILookups lookups,
+                                                              ICurrencyRounder currencyRounder,
                                                               CartContents cartContents) {
         if (cartContents.Allocations.None(x => x.UpsellOfferId.HasValue())) {
             return cartContents;
@@ -57,6 +62,7 @@ public partial class Cart {
                 var newUpsellAllocation = await upsellOfferContent.ToAllocationAsync(forexConverter,
                                                                                      priceCalculator,
                                                                                      lookups,
+                                                                                     currencyRounder,
                                                                                      Currency,
                                                                                      allocation.Value.Amount,
                                                                                      cartContents.Type,

--- a/src/Giving/N3O.Umbraco.Giving.Cart/Handlers/AddToCartHandlers.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Cart/Handlers/AddToCartHandlers.cs
@@ -2,6 +2,7 @@ using N3O.Umbraco.Content;
 using N3O.Umbraco.Context;
 using N3O.Umbraco.Entities;
 using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Financial;
 using N3O.Umbraco.Forex;
 using N3O.Umbraco.Giving.Allocations;
 using N3O.Umbraco.Giving.Allocations.Content;
@@ -31,6 +32,7 @@ public class AddToCartHandlers :
     private readonly IForexConverter _forexConverter;
     private readonly IPriceCalculator _priceCalculator;
     private readonly ILookups _lookups;
+    private readonly ICurrencyRounder _currencyRounder;
     private readonly IEnumerable<IAllocationExtensionRequestBinder> _extensionBinders;
 
     public AddToCartHandlers(ICartAccessor cartAccessor,
@@ -40,6 +42,7 @@ public class AddToCartHandlers :
                              IForexConverter forexConverter,
                              IPriceCalculator priceCalculator,
                              ILookups lookups,
+                             ICurrencyRounder currencyRounder,
                              IEnumerable<IAllocationExtensionRequestBinder> extensionBinders) {
         _cartAccessor = cartAccessor;
         _repository = repository;
@@ -48,6 +51,7 @@ public class AddToCartHandlers :
         _forexConverter = forexConverter;
         _priceCalculator = priceCalculator;
         _lookups = lookups;
+        _currencyRounder = currencyRounder;
         _extensionBinders = extensionBinders;
     }
 
@@ -75,6 +79,7 @@ public class AddToCartHandlers :
         var allocation = await upsellOfferContent.ToAllocationAsync(_forexConverter,
                                                                     _priceCalculator,
                                                                     _lookups,
+                                                                    _currencyRounder,
                                                                     currency,
                                                                     req.Model.Amount,
                                                                     upsellOfferContent.GivingType,
@@ -110,6 +115,7 @@ public class AddToCartHandlers :
                             _forexConverter,
                             _priceCalculator,
                             _lookups,
+                            _currencyRounder,
                             givingType,
                             allocation,
                             quantity);

--- a/src/Giving/N3O.Umbraco.Giving.Cart/Handlers/ClearCartHandler.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Cart/Handlers/ClearCartHandler.cs
@@ -1,5 +1,6 @@
 using N3O.Umbraco.Content;
 using N3O.Umbraco.Entities;
+using N3O.Umbraco.Financial;
 using N3O.Umbraco.Forex;
 using N3O.Umbraco.Giving.Allocations;
 using N3O.Umbraco.Giving.Cart.Commands;
@@ -16,24 +17,27 @@ public class ClearCartHandler : IRequestHandler<ClearCartCommand, ClearCartReq, 
     private readonly IForexConverter _forexConverter;
     private readonly IPriceCalculator _priceCalculator;
     private readonly ILookups _lookups;
+    private readonly ICurrencyRounder _currencyRounder;
     private readonly IRepository<Entities.Cart> _repository;
 
     public ClearCartHandler(IContentLocator contentLocator,
                             IForexConverter forexConverter,
                             IPriceCalculator priceCalculator,
                             ILookups lookups,
+                            ICurrencyRounder currencyRounder,
                             IRepository<Entities.Cart> repository) {
         _contentLocator = contentLocator;
         _forexConverter = forexConverter;
         _priceCalculator = priceCalculator;
         _lookups = lookups;
+        _currencyRounder = currencyRounder;
         _repository = repository;
     }
 
     public async Task<None> Handle(ClearCartCommand req, CancellationToken cancellationToken) {
         var cart = await req.CartId.RunAsync(_repository.GetAsync, true, cancellationToken);
 
-        await cart.RemoveAllAsync(_contentLocator, _forexConverter, _priceCalculator, _lookups, req.Model.GivingType);
+        await cart.RemoveAllAsync(_contentLocator, _forexConverter, _priceCalculator, _lookups, _currencyRounder, req.Model.GivingType);
 
         await _repository.UpdateAsync(cart, RevisionBehaviour.Unchanged);
 

--- a/src/Giving/N3O.Umbraco.Giving.Cart/Handlers/ClearCartHandler.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Cart/Handlers/ClearCartHandler.cs
@@ -37,7 +37,12 @@ public class ClearCartHandler : IRequestHandler<ClearCartCommand, ClearCartReq, 
     public async Task<None> Handle(ClearCartCommand req, CancellationToken cancellationToken) {
         var cart = await req.CartId.RunAsync(_repository.GetAsync, true, cancellationToken);
 
-        await cart.RemoveAllAsync(_contentLocator, _forexConverter, _priceCalculator, _lookups, _currencyRounder, req.Model.GivingType);
+        await cart.RemoveAllAsync(_contentLocator,
+                                  _forexConverter,
+                                  _priceCalculator,
+                                  _lookups,
+                                  _currencyRounder,
+                                  req.Model.GivingType);
 
         await _repository.UpdateAsync(cart, RevisionBehaviour.Unchanged);
 

--- a/src/Giving/N3O.Umbraco.Giving.Cart/Handlers/RemoveFromCartHandler.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Cart/Handlers/RemoveFromCartHandler.cs
@@ -1,6 +1,7 @@
 using N3O.Umbraco.Content;
 using N3O.Umbraco.Entities;
 using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Financial;
 using N3O.Umbraco.Forex;
 using N3O.Umbraco.Giving.Allocations;
 using N3O.Umbraco.Giving.Allocations.Content;
@@ -22,6 +23,7 @@ public class RemoveFromCartHandler :
     private readonly IPriceCalculator _priceCalculator;
     private readonly ICartAccessor _cartAccessor;
     private readonly ILookups _lookups;
+    private readonly ICurrencyRounder _currencyRounder;
     private readonly IRepository<Entities.Cart> _repository;
 
     public RemoveFromCartHandler(IContentLocator contentLocator,
@@ -29,12 +31,14 @@ public class RemoveFromCartHandler :
                                  IPriceCalculator priceCalculator,
                                  ICartAccessor cartAccessor,
                                  ILookups lookups,
+                                 ICurrencyRounder currencyRounder,
                                  IRepository<Entities.Cart> repository) {
         _contentLocator = contentLocator;
         _forexConverter = forexConverter;
         _priceCalculator = priceCalculator;
         _cartAccessor = cartAccessor;
         _lookups = lookups;
+        _currencyRounder = currencyRounder;
         _repository = repository;
     }
     
@@ -45,6 +49,7 @@ public class RemoveFromCartHandler :
                                    _forexConverter,
                                    _priceCalculator,
                                    _lookups,
+                                   _currencyRounder,
                                    req.Model.GivingType,
                                    req.Model.Indexes);
 
@@ -60,6 +65,7 @@ public class RemoveFromCartHandler :
                                _forexConverter,
                                _priceCalculator,
                                _lookups,
+                               _currencyRounder,
                                req.Model.GivingType,
                                req.Model.Index.GetValueOrThrow());
 
@@ -76,6 +82,7 @@ public class RemoveFromCartHandler :
                                      _forexConverter,
                                      _priceCalculator,
                                      _lookups,
+                                     _currencyRounder,
                                      upsellOfferContent.GivingType,
                                      req.UpsellOfferId.Value);
         

--- a/src/Giving/N3O.Umbraco.Giving.Cart/Modules/CartBlockModule.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Cart/Modules/CartBlockModule.cs
@@ -35,6 +35,7 @@ public class CartBlockModule : IBlockModule {
     private readonly Lazy<IPriceCalculator> _priceCalculator;
     private readonly Lazy<IQueryStringAccessor> _queryStringAccessor;
     private readonly Lazy<ILookups> _lookups;
+    private readonly Lazy<ICurrencyRounder> _currencyRounder;
 
     public CartBlockModule(Lazy<ICartAccessor> cartAccessor,
                            Lazy<IFormatter> formatter,
@@ -43,7 +44,8 @@ public class CartBlockModule : IBlockModule {
                            Lazy<IForexConverter> forexConverter,
                            Lazy<IPriceCalculator> priceCalculator,
                            Lazy<IQueryStringAccessor> queryStringAccessor,
-                           Lazy<ILookups> lookups) {
+                           Lazy<ILookups> lookups,
+                           Lazy<ICurrencyRounder> currencyRounder) {
         _cartAccessor = cartAccessor;
         _formatter = formatter;
         _contentCache = contentCache;
@@ -52,6 +54,7 @@ public class CartBlockModule : IBlockModule {
         _priceCalculator = priceCalculator;
         _queryStringAccessor = queryStringAccessor;
         _lookups = lookups;
+        _currencyRounder = currencyRounder;
     }
     
     public bool ShouldExecute(IPublishedElement block) {
@@ -87,6 +90,7 @@ public class CartBlockModule : IBlockModule {
             upsellOffers.Add(await upsellOffersContent.ToUpsellOfferAsync(_forexConverter.Value,
                                                                           _priceCalculator.Value,
                                                                           _lookups.Value,
+                                                                          _currencyRounder.Value,
                                                                           currency,
                                                                           upsellOffersContent.GivingType,
                                                                           cart.GetTotalExcludingUpsells(upsellOffersContent.GivingType)));

--- a/src/N3O.Umbraco.Extensions/Context/ContextComposer.cs
+++ b/src/N3O.Umbraco.Extensions/Context/ContextComposer.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using N3O.Umbraco.Composing;
 using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Financial;
 using Umbraco.Cms.Core.DependencyInjection;
 
 namespace N3O.Umbraco.Context;
@@ -17,6 +18,7 @@ public class ContextComposer : Composer {
         builder.Services.AddSingleton<IQueryStringAccessor, QueryStringAccessor>();
         builder.Services.TryAddSingleton<IRemoteIpAddressAccessor, RemoteIpAddressAccessor>();
         builder.Services.TryAddSingleton<IRequestHostAccessor, RequestHostAccessor>();
+        builder.Services.TryAddSingleton<ICurrencyRounder, DefaultCurrencyRounder>();
 
         RegisterCookies<ICookie>(builder);
         RegisterCookies<IReadOnlyCookie>(builder);

--- a/src/N3O.Umbraco.Extensions/Context/ContextComposer.cs
+++ b/src/N3O.Umbraco.Extensions/Context/ContextComposer.cs
@@ -16,9 +16,9 @@ public class ContextComposer : Composer {
         builder.Services.AddScoped<IDefaultCurrencyProvider, LookupsDefaultCurrencyProvider>();
         builder.Services.AddSingleton<ICurrentUrlAccessor, CurrentUrlAccessor>();
         builder.Services.AddSingleton<IQueryStringAccessor, QueryStringAccessor>();
+        builder.Services.TryAddSingleton<ICurrencyRounder, DefaultCurrencyRounder>();
         builder.Services.TryAddSingleton<IRemoteIpAddressAccessor, RemoteIpAddressAccessor>();
         builder.Services.TryAddSingleton<IRequestHostAccessor, RequestHostAccessor>();
-        builder.Services.TryAddSingleton<ICurrencyRounder, DefaultCurrencyRounder>();
 
         RegisterCookies<ICookie>(builder);
         RegisterCookies<IReadOnlyCookie>(builder);

--- a/src/N3O.Umbraco.Extensions/Extensions/MoneyExtensions.cs
+++ b/src/N3O.Umbraco.Extensions/Extensions/MoneyExtensions.cs
@@ -19,9 +19,7 @@ public static class MoneyExtensions {
     }
 
     public static Money RoundUpToWholeNumber(this Money money) {
-        var newAmount = Math.Round(money.Amount, 0, MidpointRounding.AwayFromZero);
-
-        return new Money(newAmount, money.Currency);
+        return new Money(Math.Ceiling(money.Amount), money.Currency);
     }
 
     public static IEnumerable<Money> SafeDivide(this Money money, int shares) {

--- a/src/N3O.Umbraco.Extensions/Extensions/MoneyExtensions.cs
+++ b/src/N3O.Umbraco.Extensions/Extensions/MoneyExtensions.cs
@@ -19,7 +19,9 @@ public static class MoneyExtensions {
     }
 
     public static Money RoundUpToWholeNumber(this Money money) {
-        return new Money(Math.Ceiling(money.Amount), money.Currency);
+        var newAmount = Math.Round(money.Amount, 0, MidpointRounding.AwayFromZero);
+
+        return new Money(newAmount, money.Currency);
     }
 
     public static IEnumerable<Money> SafeDivide(this Money money, int shares) {

--- a/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Default.cs
+++ b/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Default.cs
@@ -1,0 +1,8 @@
+using N3O.Umbraco.Extensions;
+
+namespace N3O.Umbraco.Financial;
+
+// Default rounds converted amounts up to a whole unit; downstream sites can register their own ICurrencyRounder
+public class DefaultCurrencyRounder : ICurrencyRounder {
+    public virtual Money Round(Money money) => money.RoundUpToWholeNumber();
+}

--- a/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Default.cs
+++ b/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Default.cs
@@ -2,7 +2,6 @@ using N3O.Umbraco.Extensions;
 
 namespace N3O.Umbraco.Financial;
 
-// Default rounds converted amounts up to a whole unit; downstream sites can register their own ICurrencyRounder
 public class DefaultCurrencyRounder : ICurrencyRounder {
     public virtual Money Round(Money money) => money.RoundUpToWholeNumber();
 }

--- a/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Default.cs
+++ b/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Default.cs
@@ -1,7 +1,7 @@
-using N3O.Umbraco.Extensions;
+using System;
 
 namespace N3O.Umbraco.Financial;
 
 public class DefaultCurrencyRounder : ICurrencyRounder {
-    public virtual Money Round(Money money) => money.RoundUpToWholeNumber();
+    public virtual Money Round(Money money) => new Money(Math.Ceiling(money.Amount), money.Currency);
 }

--- a/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Default.cs
+++ b/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Default.cs
@@ -1,7 +1,7 @@
-using System;
+using N3O.Umbraco.Extensions;
 
 namespace N3O.Umbraco.Financial;
 
 public class DefaultCurrencyRounder : ICurrencyRounder {
-    public virtual Money Round(Money money) => new Money(Math.Ceiling(money.Amount), money.Currency);
+    public virtual Money Round(Money money) => money.RoundUpToWholeNumber();
 }

--- a/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.I.cs
+++ b/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.I.cs
@@ -1,0 +1,5 @@
+namespace N3O.Umbraco.Financial;
+
+public interface ICurrencyRounder {
+    Money Round(Money money);
+}

--- a/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Null.cs
+++ b/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Null.cs
@@ -1,6 +1,5 @@
 namespace N3O.Umbraco.Financial;
 
-// Register downstream to turn rounding off; amounts pass through unchanged
 public class NullCurrencyRounder : ICurrencyRounder {
     public virtual Money Round(Money money) => money;
 }

--- a/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Null.cs
+++ b/src/N3O.Umbraco.Extensions/Financial/Currency/CurrencyRounder.Null.cs
@@ -1,0 +1,6 @@
+namespace N3O.Umbraco.Financial;
+
+// Register downstream to turn rounding off; amounts pass through unchanged
+public class NullCurrencyRounder : ICurrencyRounder {
+    public virtual Money Round(Money money) => money;
+}


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2642

## Summary

Converted (non-base) currency amounts are now rounded for the website UI so they read cleanly — e.g. £100 shows as **$104** instead of $103.78. Base currency keeps its minor units, and the calculation/validation layer (`PriceCalculator`) is left exact and untouched.

Crucially the rounding is an **overridable seam, with a default that ships in umbraco-extensions** — not a hard-coded rule:

- `ICurrencyRounder { Money Round(Money money); }` with `DefaultCurrencyRounder` rounding **up to a whole unit** (`Math.Ceiling`).
- Registered with `TryAddSingleton`, so the default is active for every site, but a downstream project can register its own `ICurrencyRounder` (`AddSingleton`, last-wins) to control the strategy — e.g. nearest 5 when over $100, nearest 10 when over $1000. A `NullCurrencyRounder` (no-op) is also provided so a site can register it to turn the behaviour off entirely.

This is a from-scratch alternative to #880 that keeps that interface/override design but fixes its main structural problem: the mapper took the rounder through its **map-source tuple**. Here `CurrencyValuesMapping` **injects** `ICurrencyRounder` via its constructor, like its existing `ILookups`/`IForexConverter` dependencies, and the map source stays `decimal` — so `PriceMapping`, `PriceHandleMapping` and `PriceCalculator` need no changes.

The rounder is applied where a base amount becomes a donor-facing foreign amount:

- `CurrencyValuesMapping` — the per-currency grid behind price handles (what the donor sees and submits). Constructor-injected.
- `UpsellOfferContentExtensions.CalculatePriceAsync` — server-computed upsell prices. The rounder is threaded through the cart/handler path it is reached from, because upsell amounts recompute server-side whenever the cart changes (`Cart.ReplaceContents` → `UpdateUpsellAmounts`); it sits alongside the `IForexConverter`/`IPriceCalculator`/`ILookups` services already passed to those entity methods.

The rounded amount then rides the existing flow into the cart, checkout and charge, and passes the existing "must be at least the exact conversion" validation because a ceiled amount is always greater than or equal to the exact conversion. Base-currency amounts and donor-entered custom amounts are left exact. Zakat is a separate module and does not flow through these conversions.

This also fixes the pre-existing `RoundUpToWholeNumber` helper, which despite its name rounded to the nearest whole number (`Math.Round`) rather than up — e.g. $52.11 became $52. It now uses `Math.Ceiling` and is the default rounder's behaviour.

### Difference from #880

Same overridable-default design, but the mapper is constructor-injected rather than fed via a `(decimal, ICurrencyRounder)` map-source tuple, and `PriceMapping`/`PriceHandleMapping`/`PriceCalculator` are untouched. The cart/handler threading is retained because it is genuinely required to reach the upsell recompute.

## Test plan

- [ ] `dotnet build` of the full solution — succeeds, 0 errors
- [ ] With the default rounder, a priced item (e.g. £100 base) displays its price handles in a non-base currency rounded up to a whole unit (e.g. $104 for a $103.78 conversion)
- [ ] Selecting that handle adds the rounded amount to the cart, and it persists through checkout and the charged total
- [ ] The rounded amount passes allocation validation (it is at least the exact conversion)
- [ ] Base-currency prices and donor-entered custom amounts are unchanged
- [ ] Upsell offer prices in a non-base currency are rounded, including after the cart changes and amounts recompute
- [ ] A downstream project that registers its own `ICurrencyRounder` (e.g. nearest 5 over $100) sees its strategy used instead of the default, with no other framework changes
