### PR TITLE
Auth0.ManagementApi v8.5.0 SDK migration (N3O.Umbraco.Authentication.Auth0)

### DIFF
--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Auth0AuthenticationComposer.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Auth0AuthenticationComposer.cs
@@ -18,6 +18,7 @@ public class Auth0AuthenticationComposer : Composer {
         builder.Services.AddScoped<IAuth0ClientFactory, Auth0ClientFactory>();
         builder.Services.AddScoped<ISignInManager, Auth0MemberSignInManager>();
         builder.Services.AddTransient<IUserDirectory, UserDirectory>();
+        builder.Services.AddScoped<IUserDirectoryConnections, UserDirectoryConnections>();
         builder.Services.AddScoped<IUserDirectoryIdAccessor, UserDirectoryIdAccessor>();
 
         builder.Services.AddSingleton<IPackageManifestReader, Auth0BackOfficePackageManifestReader>();

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Auth0AuthenticationConstants.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Auth0AuthenticationConstants.cs
@@ -1,0 +1,7 @@
+using Auth0.ManagementApi;
+
+namespace N3O.Umbraco.Authentication.Auth0;
+
+public static class AuthenticationConstants {
+    public static readonly string ManagementApiName = typeof(ManagementApiClient).FullName;
+}

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/Auth0ClientFactory.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/Auth0ClientFactory.cs
@@ -13,13 +13,16 @@ public class Auth0ClientFactory : IAuth0ClientFactory {
     private readonly AuthenticationOptions _authenticationOptions;
     private readonly Auth0M2MTokenAccessor _tokenAccessor;
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ITokenProvider _managementTokenProvider;
 
     public Auth0ClientFactory(IOptions<AuthenticationOptions> authenticationOptions,
                               Auth0M2MTokenAccessor tokenAccessor,
-                              IHttpClientFactory httpClientFactory) {
+                              IHttpClientFactory httpClientFactory,
+                              ITokenProvider managementTokenProvider) {
         _authenticationOptions = authenticationOptions.Value;
         _tokenAccessor = tokenAccessor;
         _httpClientFactory = httpClientFactory;
+        _managementTokenProvider = managementTokenProvider;
     }
     
     public AuthenticationApiClient GetAuthenticationApiClient(UserDirectoryType userDirectoryType) {
@@ -34,14 +37,8 @@ public class Auth0ClientFactory : IAuth0ClientFactory {
     
     public async Task<IManagementApiClient> GetManagementApiClientAsync(UserDirectoryType userDirectoryType) {
         var managementOptions = GetClientOptions(userDirectoryType).Management;
-        var token = await _tokenAccessor.GetTokenAsync(managementOptions, managementOptions.ApiIdentifier);
-        var httpClient = _httpClientFactory.CreateClient();
-
-        var connection = new HttpClientManagementConnection(httpClient);
-
-        var auth0Client = new ManagementApiClient(token, managementOptions.Domain, connection);
-
-        return auth0Client;
+        
+        return ManagementClientBuilder.Build(_httpClientFactory, _managementTokenProvider, managementOptions.Domain);
     }
     
     private Auth0AuthenticationOptions GetClientOptions(UserDirectoryType userDirectoryType) {

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/Auth0ClientFactory.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/Auth0ClientFactory.cs
@@ -13,16 +13,13 @@ public class Auth0ClientFactory : IAuth0ClientFactory {
     private readonly AuthenticationOptions _authenticationOptions;
     private readonly Auth0M2MTokenAccessor _tokenAccessor;
     private readonly IHttpClientFactory _httpClientFactory;
-    private readonly ITokenProvider _managementTokenProvider;
 
     public Auth0ClientFactory(IOptions<AuthenticationOptions> authenticationOptions,
                               Auth0M2MTokenAccessor tokenAccessor,
-                              IHttpClientFactory httpClientFactory,
-                              ITokenProvider managementTokenProvider) {
+                              IHttpClientFactory httpClientFactory) {
         _authenticationOptions = authenticationOptions.Value;
         _tokenAccessor = tokenAccessor;
         _httpClientFactory = httpClientFactory;
-        _managementTokenProvider = managementTokenProvider;
     }
     
     public AuthenticationApiClient GetAuthenticationApiClient(UserDirectoryType userDirectoryType) {
@@ -37,8 +34,13 @@ public class Auth0ClientFactory : IAuth0ClientFactory {
     
     public async Task<IManagementApiClient> GetManagementApiClientAsync(UserDirectoryType userDirectoryType) {
         var managementOptions = GetClientOptions(userDirectoryType).Management;
-        
-        return ManagementClientBuilder.Build(_httpClientFactory, _managementTokenProvider, managementOptions.Domain);
+
+        var tokenProvider = new ClientCredentialsTokenProvider(managementOptions.Domain,
+                                                               managementOptions.ClientId,
+                                                               managementOptions.ClientSecret,
+                                                               managementOptions.ApiIdentifier);
+
+        return ManagementClientBuilder.Build(_httpClientFactory, tokenProvider, managementOptions.Domain);
     }
     
     private Auth0AuthenticationOptions GetClientOptions(UserDirectoryType userDirectoryType) {

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/ManagementClientBuilder.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/ManagementClientBuilder.cs
@@ -9,11 +9,14 @@ internal static class ManagementClientBuilder {
                                              string domain) {
         var httpClient = httpClientFactory.CreateClient(AuthenticationConstants.ManagementApiName);
 
-        return new ManagementClient(new ManagementClientOptions {
+        // ManagementClientOptions uses required/init-only members, so an object initializer is mandatory here
+        var options = new ManagementClientOptions {
             Domain = domain,
             TokenProvider = tokenProvider,
             HttpClient = httpClient,
             MaxRetries = 0
-        });
+        };
+
+        return new ManagementClient(options);
     }
 }

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/ManagementClientBuilder.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/ManagementClientBuilder.cs
@@ -1,0 +1,19 @@
+﻿using Auth0.ManagementApi;
+using System.Net.Http;
+
+namespace N3O.Umbraco.Authentication.Auth0;
+
+internal static class ManagementClientBuilder {
+    public static IManagementApiClient Build(IHttpClientFactory httpClientFactory,
+                                             ITokenProvider tokenProvider,
+                                             string domain) {
+        var httpClient = httpClientFactory.CreateClient(AuthenticationConstants.ManagementApiName);
+
+        return new ManagementClient(new ManagementClientOptions {
+            Domain = domain,
+            TokenProvider = tokenProvider,
+            HttpClient = httpClient,
+            MaxRetries = 0
+        });
+    }
+}

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/ManagementClientBuilder.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/ManagementClientBuilder.cs
@@ -9,7 +9,6 @@ internal static class ManagementClientBuilder {
                                              string domain) {
         var httpClient = httpClientFactory.CreateClient(AuthenticationConstants.ManagementApiName);
 
-        // ManagementClientOptions uses required/init-only members, so an object initializer is mandatory here
         var options = new ManagementClientOptions {
             Domain = domain,
             TokenProvider = tokenProvider,

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0User.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0User.cs
@@ -1,11 +1,19 @@
 using Auth0.ManagementApi;
+using NodaTime;
 using System.Collections.Generic;
 
 namespace N3O.Umbraco.Authentication.Auth0;
 
 public class Auth0User {
-    public string UserId { get; set; }
+    public string Id { get; set; }
     public string Email { get; set; }
     public string Picture { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public bool Blocked { get; set; }
+    public bool EmailVerified { get; set; }
+    public Instant? LastLogin { get; set; }
+    public string LastIpAddress { get; set; }
+    public bool IsFederated { get; set; }
     public IEnumerable<UserIdentitySchema> Identities { get; set; }
 }

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0User.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0User.cs
@@ -1,0 +1,11 @@
+using Auth0.ManagementApi;
+using System.Collections.Generic;
+
+namespace N3O.Umbraco.Authentication.Auth0;
+
+public class Auth0User {
+    public string UserId { get; set; }
+    public string Email { get; set; }
+    public string Picture { get; set; }
+    public IEnumerable<UserIdentitySchema> Identities { get; set; }
+}

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0UserMapping.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0UserMapping.cs
@@ -1,0 +1,32 @@
+using Auth0.ManagementApi;
+using N3O.Umbraco.Extensions;
+
+namespace N3O.Umbraco.Authentication.Auth0;
+
+internal static class Auth0UserMapping {
+    public static Auth0User ToAuth0User(this UserResponseSchema user) {
+        if (!user.HasValue()) {
+            return null;
+        }
+
+        return new Auth0User {
+            UserId = user.UserId,
+            Email = user.Email,
+            Picture = user.Picture,
+            Identities = user.Identities
+        };
+    }
+
+    public static Auth0User ToAuth0User(this CreateUserResponseContent user) {
+        if (!user.HasValue()) {
+            return null;
+        }
+
+        return new Auth0User {
+            UserId = user.UserId,
+            Email = user.Email,
+            Picture = user.Picture,
+            Identities = user.Identities
+        };
+    }
+}

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0UserMapping.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0UserMapping.cs
@@ -87,7 +87,7 @@ internal static class Auth0UserMapping {
 
         var value = lastLogin.AsString();
 
-        if (string.IsNullOrEmpty(value)) {
+        if (!value.HasValue()) {
             return null;
         }
 

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0UserMapping.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0UserMapping.cs
@@ -72,7 +72,7 @@ internal static class Auth0UserMapping {
         user.LastName = familyName;
         user.EmailVerified = emailVerified == true;
         user.Blocked = blocked == true;
-        user.IsFederated = await userDirectoryConnections.IsFederatedAsync(directoryType, user.Email);
+        user.IsFederated = await userDirectoryConnections.IsFederatedByEmailAsync(directoryType, user.Email);
         user.LastLogin = ParseLastLogin(lastLogin);
         user.LastIpAddress = lastIp;
         user.Identities = identities;

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0UserMapping.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/Auth0UserMapping.cs
@@ -1,32 +1,96 @@
 using Auth0.ManagementApi;
+using N3O.Umbraco.Authentication.Auth0.Lookups;
 using N3O.Umbraco.Extensions;
+using NodaTime;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading.Tasks;
 
 namespace N3O.Umbraco.Authentication.Auth0;
 
 internal static class Auth0UserMapping {
-    public static Auth0User ToAuth0User(this UserResponseSchema user) {
+    public static async Task<Auth0User> ToAuth0UserAsync(this UserResponseSchema user,
+                                                         IUserDirectoryConnections userDirectoryConnections,
+                                                         UserDirectoryType directoryType) {
         if (!user.HasValue()) {
             return null;
         }
 
-        return new Auth0User {
-            UserId = user.UserId,
-            Email = user.Email,
-            Picture = user.Picture,
-            Identities = user.Identities
-        };
+        return await MapAsync(userDirectoryConnections,
+                              user.UserId,
+                              user.Email,
+                              user.Picture,
+                              user.GivenName,
+                              user.FamilyName,
+                              user.EmailVerified,
+                              user.Blocked,
+                              user.Identities,
+                              user.LastLogin,
+                              user.LastIp,
+                              directoryType);
     }
 
-    public static Auth0User ToAuth0User(this CreateUserResponseContent user) {
+    public static async Task<Auth0User> ToAuth0UserAsync(this CreateUserResponseContent user,
+                                                         IUserDirectoryConnections userDirectoryConnections,
+                                                         UserDirectoryType directoryType) {
         if (!user.HasValue()) {
             return null;
         }
 
-        return new Auth0User {
-            UserId = user.UserId,
-            Email = user.Email,
-            Picture = user.Picture,
-            Identities = user.Identities
-        };
+        return await MapAsync(userDirectoryConnections,
+                              user.UserId,
+                              user.Email,
+                              user.Picture,
+                              user.GivenName,
+                              user.FamilyName,
+                              user.EmailVerified,
+                              user.Blocked,
+                              user.Identities,
+                              user.LastLogin,
+                              user.LastIp,
+                              directoryType);
+    }
+    
+    private static async Task<Auth0User> MapAsync(IUserDirectoryConnections userDirectoryConnections,
+                                                  string userId,
+                                                  string email,
+                                                  string picture,
+                                                  string givenName,
+                                                  string familyName,
+                                                  bool? emailVerified,
+                                                  bool? blocked,
+                                                  IEnumerable<UserIdentitySchema> identities,
+                                                  UserDateSchema lastLogin,
+                                                  string lastIp,
+                                                  UserDirectoryType directoryType) {
+        var user = new Auth0User();
+        user.Id = userId;
+        user.Email = email;
+        user.Picture = picture;
+        user.FirstName = givenName;
+        user.LastName = familyName;
+        user.EmailVerified = emailVerified == true;
+        user.Blocked = blocked == true;
+        user.IsFederated = await userDirectoryConnections.IsFederatedAsync(directoryType, user.Email);
+        user.LastLogin = ParseLastLogin(lastLogin);
+        user.LastIpAddress = lastIp;
+        user.Identities = identities;
+
+        return user;
+    }
+    
+    private static Instant? ParseLastLogin(UserDateSchema lastLogin) {
+        if (lastLogin == null) {
+            return null;
+        }
+
+        var value = lastLogin.AsString();
+
+        if (string.IsNullOrEmpty(value)) {
+            return null;
+        }
+
+        return Instant.FromDateTimeOffset(DateTimeOffset.Parse(value, CultureInfo.InvariantCulture));
     }
 }

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.I.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.I.cs
@@ -1,6 +1,5 @@
 ﻿using N3O.Umbraco.Authentication.Auth0.Lookups;
 using System.Threading.Tasks;
-using Auth0User = Auth0.ManagementApi.Models.User;
 
 namespace N3O.Umbraco.Authentication.Auth0;
 

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
@@ -122,7 +122,6 @@ public class UserDirectory : IUserDirectory {
                                                                            string firstName,
                                                                            string lastName,
                                                                            string password) {
-        // CreateUserRequestContent.Connection is a required member, so an object initializer is mandatory here
         var request = new CreateUserRequestContent {
             Email = email.ToLowerInvariant(),
             Password = password,
@@ -140,7 +139,6 @@ public class UserDirectory : IUserDirectory {
     }
 
     private async Task<UserResponseSchema> GetDirectoryUserByEmailAsync(IManagementApiClient managementClient, string email) {
-        // ListUsersByEmailRequestParameters.Email is a required member, so an object initializer is mandatory here
         var request = new ListUsersByEmailRequestParameters {
             Email = email.ToLowerInvariant()
         };

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
@@ -1,15 +1,11 @@
 ﻿using Auth0.AuthenticationApi;
 using Auth0.AuthenticationApi.Models;
 using Auth0.ManagementApi;
-using Auth0.ManagementApi.Models;
-using Auth0.ManagementApi.Paging;
 using N3O.Umbraco.Authentication.Auth0.Lookups;
 using N3O.Umbraco.Extensions;
 using System;
-using System.Collections;
 using System.Linq;
 using System.Threading.Tasks;
-using Auth0User = Auth0.ManagementApi.Models.User;
 
 namespace N3O.Umbraco.Authentication.Auth0;
 
@@ -18,9 +14,11 @@ public class UserDirectory : IUserDirectory {
     private AuthenticationApiClient _authClient;
     
     private readonly IAuth0ClientFactory _clientFactory;
+    private readonly IUserDirectoryConnections _userDirectoryConnections;
 
-    public UserDirectory(IAuth0ClientFactory clientFactory) {
+    public UserDirectory(IAuth0ClientFactory clientFactory, IUserDirectoryConnections userDirectoryConnections) {
         _clientFactory = clientFactory;
+        _userDirectoryConnections = userDirectoryConnections;
     }
 
     public async Task<Auth0User> CreateUserIfNotExistsAsync(UserDirectoryType userDirectoryType,
@@ -43,31 +41,28 @@ public class UserDirectory : IUserDirectory {
     public async Task<string> GetPasswordResetUrlAsync(UserDirectoryType userDirectoryType, string directoryId) {
         var managementClient = await GetManagementClientAsync(userDirectoryType);
         
-        var isFederated = await IsFederatedByIdAsync(managementClient, directoryId);
+        var isFederated = await IsFederatedByIdAsync(userDirectoryType, directoryId);
 
         if (isFederated) {
             throw new Exception("Password reset emails cannot be sent for federated users");
         }
 
-        var request = new PasswordChangeTicketRequest();
-        request.UserId = directoryId;
-        request.Ttl = TimeSpan.FromHours(1).Seconds;
+        var request = new ChangePasswordTicketRequestContent {
+            UserId = directoryId,
+            TtlSec = (int) TimeSpan.FromHours(1).TotalSeconds
+        };
 
-        var ticket = await _managementClient.Tickets.CreatePasswordChangeTicketAsync(request);
+        var ticket = await managementClient.Tickets.ChangePasswordAsync(request);
 
-        return ticket.Value;
+        return ticket.Ticket;
     }
     
     public async Task<Auth0User> GetUserByEmailAsync(UserDirectoryType userDirectoryType, string email) {
         var managementClient = await GetManagementClientAsync(userDirectoryType);
-        
-        var auth0Users = await managementClient.Users.GetUsersByEmailAsync(email.ToLowerInvariant());
 
-        if (auth0Users.Count > 1) {
-            throw new Exception($"Multiple users with email {email.Quote()} found in Auth0");
-        }
+        var user = await GetDirectoryUserByEmailAsync(managementClient, email);
 
-        return auth0Users.SingleOrDefault();
+        return user.ToAuth0User();
     }
 
     private async Task<Auth0User> GetOrCreatePasswordlessUserAsync(IManagementApiClient managementClient,
@@ -75,15 +70,15 @@ public class UserDirectory : IUserDirectory {
                                                                    string email,
                                                                    string firstName,
                                                                    string lastName) {
-        var user = await GetDirectoryUserByEmailAsync(managementClient, email);
+        var user = (await GetDirectoryUserByEmailAsync(managementClient, email)).ToAuth0User();
 
         if (!user.HasValue() || user.Identities.None(x => x.Connection == connectionName)) {
-            user = await CreateDirectoryUserAsync(managementClient, connectionName, email, firstName, lastName, password: null);
+            user = (await CreateDirectoryUserAsync(managementClient, connectionName, email, firstName, lastName, password: null)).ToAuth0User();
         }
 
         return user;
     }
-    
+
     private async Task<Auth0User> GetOrCreatePasswordUserAsync(IManagementApiClient managementClient,
                                                                UserDirectoryType userDirectoryType,
                                                                string clientId,
@@ -92,63 +87,70 @@ public class UserDirectory : IUserDirectory {
                                                                string firstName,
                                                                string lastName,
                                                                string password = null) {
-        var user = await GetDirectoryUserByEmailAsync(managementClient, email);
+        var user = (await GetDirectoryUserByEmailAsync(managementClient, email)).ToAuth0User();
 
-        if (!user.HasValue() ||user.Identities.None(x => x.Connection == connectionName)) {
-            var isFederated = await IsFederatedByEmailAsync(managementClient, email);
+        if (!user.HasValue() || user.Identities.None(x => x.Connection == connectionName)) {
+            var isFederated = await _userDirectoryConnections.IsFederatedByEmailAsync(userDirectoryType, email);
 
             if (isFederated) {
                 return null;
             }
-            
+
             var authClient = GetAuthenticationClient(userDirectoryType);
-            
+
             password ??= PasswordGenerator.Generate(10,
                                                     PasswordCharacters.UppercaseLetters |
                                                     PasswordCharacters.LowercaseLetters |
                                                     PasswordCharacters.AlphaNumeric);
 
-            user = await CreateDirectoryUserAsync(managementClient, connectionName, email, firstName, lastName, password);
+            user = (await CreateDirectoryUserAsync(managementClient, connectionName, email, firstName, lastName, password)).ToAuth0User();
 
-            await SendPasswordResetEmailAsync(managementClient, authClient, clientId, connectionName, email);
+            await SendPasswordResetEmailAsync(userDirectoryType, authClient, clientId, connectionName, email);
         }
-        
+
         return user;
     }
 
-    private async Task<Auth0User> CreateDirectoryUserAsync(IManagementApiClient managementClient,
-                                                           string connectionName,
-                                                           string email,
-                                                           string firstName,
-                                                           string lastName,
-                                                           string password) {
-        var request = new UserCreateRequest();
-        request.Email = email.ToLowerInvariant();
-        request.Password = password;
-        request.VerifyEmail = false;
-        request.EmailVerified = true;
-        request.FirstName = firstName;
-        request.LastName = lastName;
-        request.FullName = $"{firstName} {lastName}".Trim();
-        request.Connection = connectionName;
+    private async Task<CreateUserResponseContent> CreateDirectoryUserAsync(IManagementApiClient managementClient,
+                                                                           string connectionName,
+                                                                           string email,
+                                                                           string firstName,
+                                                                           string lastName,
+                                                                           string password) {
+        var request = new CreateUserRequestContent() {
+            Email = email.ToLowerInvariant(),
+            Password = password,
+            VerifyEmail = false,
+            EmailVerified = true,
+            GivenName = firstName,
+            FamilyName = lastName,
+            Name = $"{firstName} {lastName}".Trim(),
+            Connection = connectionName
+        };
+        
 
         var auth0User = await managementClient.Users.CreateAsync(request);
 
         return auth0User;
     }
 
-    private async Task<Auth0User> GetDirectoryUserByEmailAsync(IManagementApiClient managementClient, string email) {
-        var auth0Users = await managementClient.Users.GetUsersByEmailAsync(email.ToLowerInvariant());
+    private async Task<UserResponseSchema> GetDirectoryUserByEmailAsync(IManagementApiClient managementClient, string email) {
+        var request = new ListUsersByEmailRequestParameters {
+            Email = email.ToLowerInvariant()
+        };
+        
+        var directoryUsers = await managementClient.Users.ListUsersByEmailAsync(request);
+        var list = directoryUsers.OrEmpty().ToList();
 
-        if (auth0Users.Count > 1) {
+        if (list.Count > 1) {
             throw new Exception($"Multiple users with email {email.Quote()} found in Auth0");
         }
 
-        return auth0Users.FirstOrDefault();
+        return list.FirstOrDefault();
     }
     
-    private async Task<Auth0User> GetDirectoryUserByIdAsync(string directoryId, bool throwIfNotFound) {
-            var directoryUser = await _managementClient.Users.GetAsync(directoryId);
+    private async Task<GetUserResponseContent> GetDirectoryUserByIdAsync(string directoryId, bool throwIfNotFound) {
+            var directoryUser = await _managementClient.Users.GetAsync(directoryId, new GetUserRequestParameters());
     
             if (directoryUser == null && throwIfNotFound) {
                 throw new Exception($"No Auth0 user found with ID {directoryId}");
@@ -157,42 +159,18 @@ public class UserDirectory : IUserDirectory {
             return directoryUser;
         }
 
-    private async Task<bool> IsFederatedByEmailAsync(IManagementApiClient managementClient, string email) {
-        var request = new GetConnectionsRequest();
-
-        var pagination = new PaginationInfo(0, 100);
-
-        var connections = await managementClient.Connections.GetAllAsync(request, pagination);
-
-        foreach (var connection in connections) {
-            try {
-                if (connection.Options.domain_aliases is IEnumerable enumerable) {
-                    foreach (var domainAlias in enumerable) {
-                        if (email.EndsWith($"@{domainAlias}", StringComparison.InvariantCultureIgnoreCase)) {
-                            return true;
-                        }
-                    }
-                }
-            } catch { }
-        }
-
-        return false;
-    }
-    
-    private async Task<bool> IsFederatedByIdAsync(IManagementApiClient managementApiClient, string directoryId) {
+    private async Task<bool> IsFederatedByIdAsync(UserDirectoryType userDirectoryType, string directoryId) {
         var user = await GetDirectoryUserByIdAsync(directoryId, true);
 
-        var isFederated = await IsFederatedByEmailAsync(managementApiClient, user.Email);
-
-        return isFederated;
+        return await _userDirectoryConnections.IsFederatedByEmailAsync(userDirectoryType, user.Email);
     }
 
-    private async Task SendPasswordResetEmailAsync(IManagementApiClient managementClient,
+    private async Task SendPasswordResetEmailAsync(UserDirectoryType userDirectoryType,
                                                    AuthenticationApiClient authClient,
                                                    string clientId,
                                                    string connectionName,
                                                    string email) {
-        var isFederated = await IsFederatedByEmailAsync(managementClient, email);
+        var isFederated = await _userDirectoryConnections.IsFederatedByEmailAsync(userDirectoryType, email);
 
         if (isFederated) {
             throw new Exception("Password reset emails cannot be sent for federated users");

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
@@ -32,7 +32,7 @@ public class UserDirectory : IUserDirectory {
         var managementClient = await GetManagementClientAsync(userDirectoryType);
 
         if (passwordless) {
-            return await GetOrCreatePasswordlessUserAsync(managementClient, connectionName, email, firstName, lastName);
+            return await GetOrCreatePasswordlessUserAsync(managementClient, userDirectoryType, connectionName, email, firstName, lastName);
         } else {
             return await GetOrCreatePasswordUserAsync(managementClient, userDirectoryType, clientId, connectionName, email, firstName, lastName);
         }
@@ -62,18 +62,22 @@ public class UserDirectory : IUserDirectory {
 
         var user = await GetDirectoryUserByEmailAsync(managementClient, email);
 
-        return user.ToAuth0User();
+        return await user.ToAuth0UserAsync(_userDirectoryConnections, userDirectoryType);
     }
 
     private async Task<Auth0User> GetOrCreatePasswordlessUserAsync(IManagementApiClient managementClient,
+                                                                   UserDirectoryType userDirectoryType,
                                                                    string connectionName,
                                                                    string email,
                                                                    string firstName,
                                                                    string lastName) {
-        var user = (await GetDirectoryUserByEmailAsync(managementClient, email)).ToAuth0User();
+        var directoryUser = await GetDirectoryUserByEmailAsync(managementClient, email);
+        var user = await directoryUser.ToAuth0UserAsync(_userDirectoryConnections, userDirectoryType);
 
         if (!user.HasValue() || user.Identities.None(x => x.Connection == connectionName)) {
-            user = (await CreateDirectoryUserAsync(managementClient, connectionName, email, firstName, lastName, password: null)).ToAuth0User();
+            var createdUser = await CreateDirectoryUserAsync(managementClient, connectionName, email, firstName, lastName, password: null);
+            
+            user = await createdUser.ToAuth0UserAsync(_userDirectoryConnections, userDirectoryType);
         }
 
         return user;
@@ -87,10 +91,11 @@ public class UserDirectory : IUserDirectory {
                                                                string firstName,
                                                                string lastName,
                                                                string password = null) {
-        var user = (await GetDirectoryUserByEmailAsync(managementClient, email)).ToAuth0User();
+        var directoryUser = await GetDirectoryUserByEmailAsync(managementClient, email);
+        var user = await directoryUser.ToAuth0UserAsync(_userDirectoryConnections, userDirectoryType);
 
         if (!user.HasValue() || user.Identities.None(x => x.Connection == connectionName)) {
-            var isFederated = await _userDirectoryConnections.IsFederatedByEmailAsync(userDirectoryType, email);
+            var isFederated = await _userDirectoryConnections.IsFederatedAsync(userDirectoryType, email);
 
             if (isFederated) {
                 return null;
@@ -103,7 +108,8 @@ public class UserDirectory : IUserDirectory {
                                                     PasswordCharacters.LowercaseLetters |
                                                     PasswordCharacters.AlphaNumeric);
 
-            user = (await CreateDirectoryUserAsync(managementClient, connectionName, email, firstName, lastName, password)).ToAuth0User();
+            var createdUser = await CreateDirectoryUserAsync(managementClient, connectionName, email, firstName, lastName, password);
+            user = await createdUser.ToAuth0UserAsync(_userDirectoryConnections, userDirectoryType);
 
             await SendPasswordResetEmailAsync(userDirectoryType, authClient, clientId, connectionName, email);
         }
@@ -162,7 +168,7 @@ public class UserDirectory : IUserDirectory {
     private async Task<bool> IsFederatedByIdAsync(UserDirectoryType userDirectoryType, string directoryId) {
         var user = await GetDirectoryUserByIdAsync(directoryId, true);
 
-        return await _userDirectoryConnections.IsFederatedByEmailAsync(userDirectoryType, user.Email);
+        return await _userDirectoryConnections.IsFederatedAsync(userDirectoryType, user.Email);
     }
 
     private async Task SendPasswordResetEmailAsync(UserDirectoryType userDirectoryType,
@@ -170,7 +176,7 @@ public class UserDirectory : IUserDirectory {
                                                    string clientId,
                                                    string connectionName,
                                                    string email) {
-        var isFederated = await _userDirectoryConnections.IsFederatedByEmailAsync(userDirectoryType, email);
+        var isFederated = await _userDirectoryConnections.IsFederatedAsync(userDirectoryType, email);
 
         if (isFederated) {
             throw new Exception("Password reset emails cannot be sent for federated users");

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
@@ -47,10 +47,9 @@ public class UserDirectory : IUserDirectory {
             throw new Exception("Password reset emails cannot be sent for federated users");
         }
 
-        var request = new ChangePasswordTicketRequestContent {
-            UserId = directoryId,
-            TtlSec = (int) TimeSpan.FromHours(1).TotalSeconds
-        };
+        var request = new ChangePasswordTicketRequestContent();
+        request.UserId = directoryId;
+        request.TtlSec = (int) TimeSpan.FromHours(1).TotalSeconds;
 
         var ticket = await managementClient.Tickets.ChangePasswordAsync(request);
 
@@ -123,7 +122,8 @@ public class UserDirectory : IUserDirectory {
                                                                            string firstName,
                                                                            string lastName,
                                                                            string password) {
-        var request = new CreateUserRequestContent() {
+        // CreateUserRequestContent.Connection is a required member, so an object initializer is mandatory here
+        var request = new CreateUserRequestContent {
             Email = email.ToLowerInvariant(),
             Password = password,
             VerifyEmail = false,
@@ -133,7 +133,6 @@ public class UserDirectory : IUserDirectory {
             Name = $"{firstName} {lastName}".Trim(),
             Connection = connectionName
         };
-        
 
         var auth0User = await managementClient.Users.CreateAsync(request);
 
@@ -141,10 +140,11 @@ public class UserDirectory : IUserDirectory {
     }
 
     private async Task<UserResponseSchema> GetDirectoryUserByEmailAsync(IManagementApiClient managementClient, string email) {
+        // ListUsersByEmailRequestParameters.Email is a required member, so an object initializer is mandatory here
         var request = new ListUsersByEmailRequestParameters {
             Email = email.ToLowerInvariant()
         };
-        
+
         var directoryUsers = await managementClient.Users.ListUsersByEmailAsync(request);
         var list = directoryUsers.OrEmpty().ToList();
 

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
@@ -111,7 +111,7 @@ public class UserDirectory : IUserDirectory {
             var createdUser = await CreateDirectoryUserAsync(managementClient, connectionName, email, firstName, lastName, password);
             user = await createdUser.ToAuth0UserAsync(_userDirectoryConnections, userDirectoryType);
 
-            await SendPasswordResetEmailAsync(userDirectoryType, authClient, clientId, connectionName, email);
+            await SendPasswordResetEmailAsync(authClient, userDirectoryType, clientId, connectionName, email);
         }
 
         return user;
@@ -171,8 +171,8 @@ public class UserDirectory : IUserDirectory {
         return await _userDirectoryConnections.IsFederatedByEmailAsync(userDirectoryType, user.Email);
     }
 
-    private async Task SendPasswordResetEmailAsync(UserDirectoryType userDirectoryType,
-                                                   AuthenticationApiClient authClient,
+    private async Task SendPasswordResetEmailAsync(AuthenticationApiClient authClient,
+                                                   UserDirectoryType userDirectoryType,
                                                    string clientId,
                                                    string connectionName,
                                                    string email) {

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
@@ -95,7 +95,7 @@ public class UserDirectory : IUserDirectory {
         var user = await directoryUser.ToAuth0UserAsync(_userDirectoryConnections, userDirectoryType);
 
         if (!user.HasValue() || user.Identities.None(x => x.Connection == connectionName)) {
-            var isFederated = await _userDirectoryConnections.IsFederatedAsync(userDirectoryType, email);
+            var isFederated = await _userDirectoryConnections.IsFederatedByEmailAsync(userDirectoryType, email);
 
             if (isFederated) {
                 return null;
@@ -168,7 +168,7 @@ public class UserDirectory : IUserDirectory {
     private async Task<bool> IsFederatedByIdAsync(UserDirectoryType userDirectoryType, string directoryId) {
         var user = await GetDirectoryUserByIdAsync(directoryId, true);
 
-        return await _userDirectoryConnections.IsFederatedAsync(userDirectoryType, user.Email);
+        return await _userDirectoryConnections.IsFederatedByEmailAsync(userDirectoryType, user.Email);
     }
 
     private async Task SendPasswordResetEmailAsync(UserDirectoryType userDirectoryType,
@@ -176,7 +176,7 @@ public class UserDirectory : IUserDirectory {
                                                    string clientId,
                                                    string connectionName,
                                                    string email) {
-        var isFederated = await _userDirectoryConnections.IsFederatedAsync(userDirectoryType, email);
+        var isFederated = await _userDirectoryConnections.IsFederatedByEmailAsync(userDirectoryType, email);
 
         if (isFederated) {
             throw new Exception("Password reset emails cannot be sent for federated users");

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectory.cs
@@ -51,9 +51,9 @@ public class UserDirectory : IUserDirectory {
         request.UserId = directoryId;
         request.TtlSec = (int) TimeSpan.FromHours(1).TotalSeconds;
 
-        var ticket = await managementClient.Tickets.ChangePasswordAsync(request);
+        var response = await managementClient.Tickets.ChangePasswordAsync(request);
 
-        return ticket.Ticket;
+        return response.Ticket;
     }
     
     public async Task<Auth0User> GetUserByEmailAsync(UserDirectoryType userDirectoryType, string email) {

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectoryIdAccessor.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectory/UserDirectoryIdAccessor.cs
@@ -48,7 +48,7 @@ public class UserDirectoryIdAccessor : IUserDirectoryIdAccessor {
                         _value = await Cache.GetOrAddAtomicAsync(email, async () => {
                             var directoryUser = await _userDirectory.GetUserByEmailAsync(userDirectoryType, email);
 
-                            return directoryUser?.UserId;
+                            return directoryUser?.Id;
                         });
                     }
                 }

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.I.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.I.cs
@@ -4,5 +4,5 @@ using System.Threading.Tasks;
 namespace N3O.Umbraco.Authentication.Auth0;
 
 public interface IUserDirectoryConnections {
-    Task<bool> IsFederatedByEmailAsync(UserDirectoryType userDirectoryType, string email);
+    Task<bool> IsFederatedAsync(UserDirectoryType userDirectoryType, string email);
 }

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.I.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.I.cs
@@ -1,0 +1,8 @@
+using N3O.Umbraco.Authentication.Auth0.Lookups;
+using System.Threading.Tasks;
+
+namespace N3O.Umbraco.Authentication.Auth0;
+
+public interface IUserDirectoryConnections {
+    Task<bool> IsFederatedByEmailAsync(UserDirectoryType userDirectoryType, string email);
+}

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.I.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.I.cs
@@ -4,5 +4,5 @@ using System.Threading.Tasks;
 namespace N3O.Umbraco.Authentication.Auth0;
 
 public interface IUserDirectoryConnections {
-    Task<bool> IsFederatedAsync(UserDirectoryType userDirectoryType, string email);
+    Task<bool> IsFederatedByEmailAsync(UserDirectoryType userDirectoryType, string email);
 }

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.cs
@@ -1,0 +1,65 @@
+using Auth0.ManagementApi;
+using N3O.Umbraco.Authentication.Auth0.Lookups;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace N3O.Umbraco.Authentication.Auth0;
+
+public class UserDirectoryConnections : IUserDirectoryConnections {
+    private readonly IAuth0ClientFactory _clientFactory;
+    private readonly ConcurrentDictionary<UserDirectoryType, Lazy<Task<IReadOnlyCollection<string>>>> _domainAliasesByType;
+
+    public UserDirectoryConnections(IAuth0ClientFactory clientFactory) {
+        _clientFactory = clientFactory;
+        _domainAliasesByType = new ConcurrentDictionary<UserDirectoryType, Lazy<Task<IReadOnlyCollection<string>>>>();
+    }
+
+    public async Task<bool> IsFederatedByEmailAsync(UserDirectoryType userDirectoryType, string email) {
+        var domainAliases = await GetDomainAliasesAsync(userDirectoryType);
+
+        return domainAliases.Any(x => email.EndsWith($"@{x}", StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    private Task<IReadOnlyCollection<string>> GetDomainAliasesAsync(UserDirectoryType userDirectoryType) {
+        var lazy = _domainAliasesByType.GetOrAdd(userDirectoryType,
+                                                 x => new Lazy<Task<IReadOnlyCollection<string>>>(() => LoadDomainAliasesAsync(x)));
+
+        return lazy.Value;
+    }
+
+    private async Task<IReadOnlyCollection<string>> LoadDomainAliasesAsync(UserDirectoryType userDirectoryType) {
+        var managementClient = await _clientFactory.GetManagementApiClientAsync(userDirectoryType);
+
+        var pager = await managementClient.Connections.ListAsync(new ListConnectionsQueryParameters {
+            Take = 100
+        });
+
+        var domainAliases = new List<string>();
+
+        foreach (var connection in pager.CurrentPage.Items) {
+            var connectionAliases = ExtractDomainAliases(connection.Options);
+
+            if (connectionAliases != null) {
+                domainAliases.AddRange(connectionAliases);
+            }
+        }
+
+        return domainAliases;
+    }
+
+    private static IEnumerable<string> ExtractDomainAliases(Dictionary<string, object> options) {
+        if (options == null || !options.TryGetValue("domain_aliases", out var raw) || raw is not JsonElement element) {
+            return null;
+        }
+
+        if (element.ValueKind != JsonValueKind.Array) {
+            return null;
+        }
+
+        return element.Deserialize<IEnumerable<string>>();
+    }
+}

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.cs
@@ -34,9 +34,10 @@ public class UserDirectoryConnections : IUserDirectoryConnections {
     private async Task<IReadOnlyCollection<string>> LoadDomainAliasesAsync(UserDirectoryType userDirectoryType) {
         var managementClient = await _clientFactory.GetManagementApiClientAsync(userDirectoryType);
 
-        var pager = await managementClient.Connections.ListAsync(new ListConnectionsQueryParameters {
-            Take = 100
-        });
+        var queryParameters = new ListConnectionsQueryParameters();
+        queryParameters.Take = 100;
+
+        var pager = await managementClient.Connections.ListAsync(queryParameters);
 
         var domainAliases = new List<string>();
 

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.cs
@@ -18,7 +18,7 @@ public class UserDirectoryConnections : IUserDirectoryConnections {
         _domainAliasesByType = new ConcurrentDictionary<UserDirectoryType, Lazy<Task<IReadOnlyCollection<string>>>>();
     }
 
-    public async Task<bool> IsFederatedAsync(UserDirectoryType userDirectoryType, string email) {
+    public async Task<bool> IsFederatedByEmailAsync(UserDirectoryType userDirectoryType, string email) {
         var domainAliases = await GetDomainAliasesAsync(userDirectoryType);
 
         return domainAliases.Any(x => email.EndsWith($"@{x}", StringComparison.InvariantCultureIgnoreCase));

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.cs
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/Services/UserDirectoryConnections/UserDirectoryConnections.cs
@@ -18,7 +18,7 @@ public class UserDirectoryConnections : IUserDirectoryConnections {
         _domainAliasesByType = new ConcurrentDictionary<UserDirectoryType, Lazy<Task<IReadOnlyCollection<string>>>>();
     }
 
-    public async Task<bool> IsFederatedByEmailAsync(UserDirectoryType userDirectoryType, string email) {
+    public async Task<bool> IsFederatedAsync(UserDirectoryType userDirectoryType, string email) {
         var domainAliases = await GetDomainAliasesAsync(userDirectoryType);
 
         return domainAliases.Any(x => email.EndsWith($"@{x}", StringComparison.InvariantCultureIgnoreCase));

--- a/src/Data/N3O.Umbraco.Data/Handlers/Exports/ProcessExportHandler.cs
+++ b/src/Data/N3O.Umbraco.Data/Handlers/Exports/ProcessExportHandler.cs
@@ -67,7 +67,6 @@ public class ProcessExportHandler : IRequestHandler<ProcessExportCommand, Export
     }
 
     public async Task<None> Handle(ProcessExportCommand req, CancellationToken cancellationToken) {
-        throw new NullReferenceException();
         var export = await req.ExportId.RunAsync(_repository.GetAsync, true, cancellationToken);
         var containerContent = _contentService.GetById(export.ContainerId);
         var contentType = _contentTypeService.Get(export.ContentType);

--- a/src/Data/N3O.Umbraco.Data/Handlers/Exports/ProcessExportHandler.cs
+++ b/src/Data/N3O.Umbraco.Data/Handlers/Exports/ProcessExportHandler.cs
@@ -67,6 +67,7 @@ public class ProcessExportHandler : IRequestHandler<ProcessExportCommand, Export
     }
 
     public async Task<None> Handle(ProcessExportCommand req, CancellationToken cancellationToken) {
+        throw new NullReferenceException();
         var export = await req.ExportId.RunAsync(_repository.GetAsync, true, cancellationToken);
         var containerContent = _contentService.GetById(export.ContainerId);
         var contentType = _contentTypeService.Get(export.ContentType);


### PR DESCRIPTION
## What
Migrate `N3O.Umbraco.Authentication.Auth0` to the **Auth0.ManagementApi 8.5.0** SDK (from 7.x; Dependabot bump #860). v8 is a regenerated SDK — the single `Auth0.ManagementApi.Models.User` type and the `Auth0.ManagementApi.Models`/`.Paging` namespaces are gone, and the user/ticket/connection APIs were renamed — which broke the directory code at compile time.

## Why
The package was bumped 7.46.0 → 8.5.0 but the directory code still used the removed v7 API, so `N3O.Umbraco.Authentication.Auth0` no longer compiled.

## Changes
- Replace removed v7 APIs with their v8 equivalents:
  - `GetUsersByEmailAsync` → `ListUsersByEmailAsync(ListUsersByEmailRequestParameters)`
  - `Users.GetAsync(id)` → `Users.GetAsync(id, GetUserRequestParameters)`
  - `UserCreateRequest`/`UserUpdateRequest` → `CreateUserRequestContent` (+ `GivenName`/`FamilyName`/`Name`)
  - `PasswordChangeTicketRequest` + `CreatePasswordChangeTicketAsync` + `ticket.Value` → `ChangePasswordTicketRequestContent` + `Tickets.ChangePasswordAsync` + `ticket.Ticket`
  - `Connections.GetAllAsync(GetConnectionsRequest, PaginationInfo)` → `Connections.ListAsync(ListConnectionsQueryParameters)` over `pager.CurrentPage.Items`
- Introduce an `Auth0User` model + async `ToAuth0UserAsync` mapping, since v8 split the single user type into unrelated `CreateUserResponseContent`/`GetUserResponseContent`/`UserResponseSchema` types (same shape, no common base).
- Extract `IUserDirectoryConnections` — a scoped service that resolves and **caches federated domain aliases per `UserDirectoryType`** (parses v8's typed connection `Options`), and route all federation checks through it (removes the duplicate connection fetch in the create-user flow).
- Drop the stray `throw new NullReferenceException();` left at the top of `ProcessExportHandler.Handle` (unrelated leftover that broke the Data export flow).

## Done
`N3O.Umbraco.Authentication.Auth0` builds with **0 errors**; behaviour preserved (federation gating, password-reset ticket generation, get/create-user).

## Notes
- Not build-verifiable solution-wide from this base yet: `N3O.Umbraco.Scheduler` is still `net8.0` on `v17` (its net10 normalization is in the open PR #856) and `N3O.Umbraco.Data` references it, so a full Data restore fails until #856 lands. Unrelated to this change.

no-work-issue