### PR TITLE
Validate dictionary translation placeholders on save

### DIFF
--- a/src/N3O.Umbraco.Extensions/Localization/Text/TextContainerContentValidator.cs
+++ b/src/N3O.Umbraco.Extensions/Localization/Text/TextContainerContentValidator.cs
@@ -1,0 +1,58 @@
+using N3O.Umbraco.Content;
+using N3O.Umbraco.Extensions;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace N3O.Umbraco.Localization;
+
+public class TextContainerContentValidator : ContentValidator {
+    private static readonly string TextContainerAlias = AliasHelper<TextContainerContent>.ContentTypeAlias();
+    private static readonly string ResourcesAlias = AliasHelper<TextContainerContent>.PropertyAlias(x => x.Resources);
+    private static readonly Regex PlaceholderRegex = new(@"\{\{|\}\}|\{(\d+)\}", RegexOptions.Compiled);
+
+    public TextContainerContentValidator(IContentHelper contentHelper) : base(contentHelper) { }
+
+    public override bool IsValidator(ContentProperties content) {
+        return content.ContentTypeAlias.EqualsInvariant(TextContainerAlias);
+    }
+
+    public override void Validate(ContentProperties content) {
+        var json = content.GetPropertyValueByAlias<string>(ResourcesAlias);
+
+        if (!json.HasValue()) {
+            return;
+        }
+
+        var resources = JsonConvert.DeserializeObject<IEnumerable<TextResource>>(json).OrEmpty();
+
+        foreach (var resource in resources) {
+            if (resource.Custom.HasValue()) {
+                var sourcePlaceholders = GetPlaceholders(resource.Source);
+                var customPlaceholders = GetPlaceholders(resource.Custom);
+
+                if (!sourcePlaceholders.SetEquals(customPlaceholders)) {
+                    var expected = sourcePlaceholders.Any()
+                                       ? string.Join(", ", sourcePlaceholders.OrderBy(x => x).Select(x => "{" + x + "}"))
+                                       : "no placeholders";
+
+                    ErrorResult($"The translation for {resource.Source.Quote()} must use the same placeholders as " +
+                                $"the original text ({expected})");
+                }
+            }
+        }
+    }
+
+    private static HashSet<string> GetPlaceholders(string text) {
+        var placeholders = new HashSet<string>();
+
+        foreach (Match match in PlaceholderRegex.Matches(text.Or(string.Empty))) {
+            if (match.Groups[1].Success) {
+                placeholders.Add(match.Groups[1].Value);
+            }
+        }
+
+        return placeholders;
+    }
+}


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#485

## Summary

Dictionary entries (Text Container nodes) hold a `Source` string and an optional `Custom` translation, and are rendered through `string.Format(text, args)`. When a translation drops, adds, or mis-numbers a `{0}`-style placeholder it either loses data or throws a `FormatException` at render time, with nothing stopping the bad value being saved.

This adds `TextContainerContentValidator`, which runs on save and, for each resource whose `Custom` value is set, compares the set of placeholder indices in the translation against those in the source. If they don't match, the save is blocked with a message naming the source string and the placeholders it expects.

It follows the existing auto-discovered `IContentValidator` pattern (same as `RedirectContentValidator`), so no extra wiring is needed. It reads the raw `resources` JSON off the content and deserialises to `TextResource[]`; `{{`/`}}` are treated as escaped literals (matching `string.Format`) so they aren't counted as placeholders; and because the save pipeline already iterates edited cultures, culture-varying dictionaries are validated per culture automatically.

## Test plan

- [x] Mismatched translation (source `Hello {0}, welcome to {1}`, custom drops the placeholders) — save is blocked with `400 Cancelled by notification` and the message "The translation for 'Hello {0}, welcome to {1}' must use the same placeholders as the original text ({0}, {1})".
- [x] Matching translation (custom keeps `{0}` and `{1}`) — saves successfully.
- [x] Escaped braces (`{{0}}`) are not counted as placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
