### PR TITLE
Add SiteLanguageTag to CheckoutWebhookTransform

### DIFF
--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Webhooks/CheckoutWebhookTransform.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Webhooks/CheckoutWebhookTransform.cs
@@ -6,6 +6,7 @@ using N3O.Umbraco.Giving.Allocations;
 using N3O.Umbraco.Giving.Allocations.Lookups;
 using N3O.Umbraco.Giving.Allocations.Models;
 using N3O.Umbraco.Json;
+using N3O.Umbraco.Localization;
 using N3O.Umbraco.Lookups;
 using N3O.Umbraco.Payments.Content;
 using N3O.Umbraco.Payments.Lookups;
@@ -110,8 +111,10 @@ public class CheckoutWebhookTransform : WebhookTransform {
     }
     
     private void TransformTags(JObject jObject) {
-        if (Site.Language.HasValue()) {
-            AddTag(jObject, "SiteLanguageTag", Site.Language);
+        var language = LocalizationSettings.GetLanguageName(LocalizationSettings.CultureCode) ?? Site.Language;
+
+        if (language.HasValue()) {
+            AddTag(jObject, "SiteLanguageTag", language);
         }
 
         if (Site.Id.HasValue()) {

--- a/src/N3O.Umbraco.Extensions/Localization/LocalizationSettings.cs
+++ b/src/N3O.Umbraco.Extensions/Localization/LocalizationSettings.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 
@@ -27,4 +28,15 @@ public class LocalizationSettings : Value {
     public Timezone Timezone { get; }
     
     public static string CultureCode => Thread.CurrentThread.CurrentCulture.ToString();
+
+    public static string GetLanguageName(string cultureCode) {
+        try {
+            var requestedCulture = CultureInfo.GetCultureInfo(cultureCode);
+            var languageCulture = CultureInfo.GetCultureInfo(requestedCulture.TwoLetterISOLanguageName);
+
+            return languageCulture.EnglishName;
+        } catch {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
## What

`CheckoutWebhookTransform.TransformTags` now derives the `SiteLanguageTag` from the current request culture, mapped to a language name, falling back to the previous `Site.Language` behaviour when unavailable.

- Adds a shared `LocalizationSettings.GetLanguageName(cultureCode)` helper (next to the existing static `CultureCode`) that maps a culture code to its neutral culture's English language name (e.g. `en-GB` -> "English", `ar` -> "Arabic"), returning `null` for unrecognised codes.
- `TransformTags` uses `LocalizationSettings.GetLanguageName(LocalizationSettings.CultureCode)` and falls back to `Site.Language` (the `N3O_SiteLanguage` env var).

## Why

`GetLanguageName` was a private helper; it is moved to the common `LocalizationSettings` type so it can be reused. The tag now reflects a language name rather than a raw env var value.

## Notes

- Name mapping uses the neutral culture's `EnglishName`, which is locale-invariant.
- No work issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)