### PR TITLE
fix(payments): format idempotency key hash with InvariantCulture

### DIFF
--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.FormatTransactionText.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.FormatTransactionText.cs
@@ -1,5 +1,6 @@
 using N3O.Umbraco.Extensions;
 using System;
+using System.Globalization;
 
 namespace N3O.Umbraco.Giving.Checkout.Entities;
 
@@ -10,7 +11,7 @@ public partial class Checkout {
                               Progress.CurrentStage.TransactionIdPrefix,
                               StringComparison.InvariantCultureIgnoreCase)
                      .Replace("{IdempotencyKey}",
-                              idempotencyKey?.GetDeterministicHashCode(true).ToString(),
-                              StringComparison.CurrentCultureIgnoreCase);
+                              idempotencyKey?.GetDeterministicHashCode(true).ToString(CultureInfo.InvariantCulture),
+                              StringComparison.InvariantCultureIgnoreCase);
     }
 }


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#2880

## Summary

`Checkout.FormatTransactionText` built the `{IdempotencyKey}` substitution as `idempotencyKey.GetDeterministicHashCode(true).ToString()` with no `IFormatProvider`, so it used the request-thread culture. `GetDeterministicHashCode` returns a *signed* int (negative ~50% of the time); in cultures whose negative sign is non-ASCII, a negative int's `ToString()` injects that sign — e.g. Arabic `ar-*` gains a leading **U+061C** before the minus (`-1740247756` → `؜-1740247756`). Stripe.net then rejects the non-ASCII `Idempotency-Key` header with `HttpRequestException: Request headers must contain only ASCII characters`. Confirmed empirically on .NET 8/9 ICU.

**Not Arabic-only:** a scan of every .NET culture found **41 cultures** with a non-ASCII negative sign that hit this (Arabic U+061C, Persian `fa-*` U+200E+U+2212, Estonian/Basque U+2212, …). Positive hashes are ASCII in every culture, so the crash is confined to negative hashes in those 41.

This method is the single chokepoint that produces `{IdempotencyKey}` for every provider, so one fix covers Stripe (`CreatePaymentIntentHandler` + `CreateSetupIntentHandler`), Opayo `vendorTxCode`, and PayPal `SoftDescriptor`.

Both changes are in `Checkout.FormatTransactionText`:

- Format the hash with `CultureInfo.InvariantCulture`. Output is identical to what `en-US` already produces in production, so nothing changes for any currently-working culture — only the broken locales (`ar-*`, `fa-IR`, `ps-AF`, …) now emit ASCII.
- Match the `{IdempotencyKey}` placeholder with `InvariantCultureIgnoreCase` instead of `CurrentCultureIgnoreCase` — a second latent bug where under `tr-TR` the dotless-i rule meant the placeholder wouldn't match and the literal `{IdempotencyKey}` string would ship as the key.

`GetDeterministicHashCode` itself is left unchanged: its only other caller (`UmbracoId.Generate`) is culture-safe via `.ToGuid()`, and changing the helper's return would regenerate every deterministic Umbraco ID.

## Safety — no idempotency-key regression

Since the output is used as a Stripe `IdempotencyKey` (and Opayo `vendorTxCode` / PayPal `SoftDescriptor`), the concern is whether any *previously-working* key changes value. It cannot. A scan of every .NET culture confirms the set of values that change and the set of values that ever reached the provider are **disjoint**:

- **Positive hashes:** byte-identical in every culture (0 differ from invariant) → unchanged.
- **Negative hashes:** 41 cultures differ from invariant, and **all 41 are non-ASCII** — i.e. they always threw `Request headers must contain only ASCII characters` *before* the provider API call, so no key with that value was ever accepted. The corrected value is now the same ASCII form `en-*` already produces.
- The key is derived deterministically from the seed (`PaymentMethodId` / `AuthorizationId` / `CardIdentifier`), so a retry regenerates the same key — idempotency across the deploy is preserved for every culture that was working, and the crashing cultures had no in-flight provider-side state to duplicate.

## Test plan

- [x] `dotnet build N3O.Umbraco.Giving.Checkout` — 0 errors, 0 warnings (net8.0)
- [x] Confirmed `(-1740247756).ToString(CultureInfo.InvariantCulture)` is pure ASCII vs `؜-1740247756` (bytes `D8 9C …`) under `ar-SA`
- [ ] Arabic-locale (`/ar`) donation through Stripe checkout creates a PaymentIntent with no ASCII-header exception
