### PR TITLE
Generate embed codes for offerings (funds)

### DIFF
--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Notifications/Offerings/OfferingSending.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Notifications/Offerings/OfferingSending.cs
@@ -1,11 +1,17 @@
 ﻿using Flurl;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using N3O.Umbraco.Cloud.Content.Clients;
+using N3O.Umbraco.Cloud.Extensions;
+using N3O.Umbraco.Cloud.Platforms.Content;
 using N3O.Umbraco.Cloud.Platforms.Extensions;
+using N3O.Umbraco.Cloud.Platforms.Lookups;
 using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Utilities;
 using Slugify;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Umbraco.Cms.Core.Events;
@@ -13,6 +19,7 @@ using Umbraco.Cms.Core.Models.ContentEditing;
 using Umbraco.Cms.Core.Notifications;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Services;
+using Umbraco.Extensions;
 
 namespace N3O.Umbraco.Cloud.Platforms.Notifications;
 
@@ -39,6 +46,7 @@ public class OfferingSending : INotificationAsyncHandler<SendingContentNotificat
 
         if (isOffering) {
             foreach (var variant in notification.Content.Variants) {
+                SetEmbedCode(variant, notification.Content.Key.GetValueOrDefault());
                 SetUrl( notification, variant);
             }
         }
@@ -65,5 +73,35 @@ public class OfferingSending : INotificationAsyncHandler<SendingContentNotificat
                 notification.Content.Urls = urls.ToArray();
             }
         }
+    }
+    
+    private void SetEmbedCode(ContentVariantDisplay variant, Guid contentId) {
+        var donationButtonTag = new TagBuilder(ElementTypes.DonationButton.TagName);
+        var donationFormTag = new TagBuilder(ElementTypes.DonationForm.TagName);
+        var donationPopupTag = new TagBuilder(ElementTypes.DonationPopup.TagName);
+
+        donationButtonTag.Attributes.Add("element-id", $"{contentId.ToString()}");
+        donationFormTag.Attributes.Add("element-id", $"{contentId.ToString()}");
+        donationPopupTag.Attributes.Add("element-id", $"{contentId.ToString()}");
+
+        donationButtonTag.Attributes.Add("element-kind", ElementKind.DonationButtonOffering.ToEnumString());
+        donationFormTag.Attributes.Add("element-kind", ElementKind.DonationFormOffering.ToEnumString());
+        donationPopupTag.Attributes.Add("element-kind", ElementKind.DonationPopupOffering.ToEnumString());
+        
+        var embedTab = variant.Tabs
+                              .SingleOrDefault(x => x.Properties.OrEmpty().Any(y => y.Alias.IsAnyOf(AliasHelper<OfferingContent>.PropertyAlias(z => z.DonationFormEmbedCode),
+                                                                                                    AliasHelper<OfferingContent>.PropertyAlias(z => z.DonationButtonEmbedCode))));
+        
+        var donationButtonEmbedProperty = GetProperty(embedTab, AliasHelper<OfferingContent>.PropertyAlias(x => x.DonationButtonEmbedCode));
+        var donationFormTagEmbedProperty = GetProperty(embedTab, AliasHelper<OfferingContent>.PropertyAlias(x => x.DonationFormEmbedCode));
+        var donationPopupEmbedProperty = GetProperty(embedTab, AliasHelper<OfferingContent>.PropertyAlias(x => x.DonationPopupEmbedCode));
+        
+        donationButtonEmbedProperty.IfNotNull(x => x.Value = donationButtonTag.ToHtmlString());
+        donationFormTagEmbedProperty.IfNotNull(x => x.Value = donationFormTag.ToHtmlString());
+        donationPopupEmbedProperty.IfNotNull(x => x.Value = donationPopupTag.ToHtmlString());
+    }
+    
+    private ContentPropertyDisplay GetProperty(Tab<ContentPropertyDisplay> tab, string alias) {
+        return tab?.Properties?.SingleOrDefault(x => x.Alias.EqualsInvariant(alias));
     }
 }


### PR DESCRIPTION
Generates Donation Button / Form / Popup embed codes for offerings (funds) when their content is sent for rendering, mirroring how embed codes are already produced for campaigns. Previously funds had no embed codes under the Embed heading.

`OfferingSending.SetEmbedCode` builds the three donation element tags (`element-id` = content key, `element-kind` = the offering variants) and writes them into the `DonationButtonEmbedCode` / `DonationFormEmbedCode` / `DonationPopupEmbedCode` properties on the offering variant's embed tab.

Also includes a minor culture-formatting adjustment in `Checkout.FormatTransactionText` (drops the explicit `CultureInfo.InvariantCulture` on the idempotency-key hash and switches to `CurrentCultureIgnoreCase`).

## Release notes
Fund donation forms and buttons now generate embed codes under the Embed heading, matching campaigns.

re n3oltd/work#2870