### PR TITLE
fix(open-graph): preserve query string when building image URL

### DIFF
--- a/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.I.cs
+++ b/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.I.cs
@@ -3,8 +3,8 @@
 public interface IOpenGraphBuilder {
     IOpenGraphBuilder WithTitle(string title);
     IOpenGraphBuilder WithDescription(string description);
-    IOpenGraphBuilder WithRelativeImageUrl(string relativeImageUrl);
     IOpenGraphBuilder WithImageUrl(string imageUrl);
+    IOpenGraphBuilder WithRelativeImageUrl(string relativeImageUrl);
     IOpenGraphBuilder WithUrl(string url);
 
     OpenGraphData Build();

--- a/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.I.cs
+++ b/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.I.cs
@@ -3,7 +3,7 @@
 public interface IOpenGraphBuilder {
     IOpenGraphBuilder WithTitle(string title);
     IOpenGraphBuilder WithDescription(string description);
-    IOpenGraphBuilder WithImagePath(string imagePath);
+    IOpenGraphBuilder WithRelativeImageUrl(string relativeImageUrl);
     IOpenGraphBuilder WithImageUrl(string imageUrl);
     IOpenGraphBuilder WithUrl(string url);
 

--- a/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.cs
+++ b/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.cs
@@ -1,3 +1,4 @@
+using Flurl;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Utilities;
 
@@ -27,7 +28,7 @@ public class OpenGraphBuilder : IOpenGraphBuilder {
     }
 
     public IOpenGraphBuilder WithImagePath(string imagePath) {
-        var imageUrl = _urlBuilder.Root().AppendPathSegment(imagePath);
+        var imageUrl = Url.Combine(_urlBuilder.Root(), imagePath);
 
         return WithImageUrl(imageUrl);
     }

--- a/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.cs
+++ b/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.cs
@@ -27,16 +27,16 @@ public class OpenGraphBuilder : IOpenGraphBuilder {
         return this;
     }
 
-    public IOpenGraphBuilder WithRelativeImageUrl(string relativeImageUrl) {
-        var imageUrl = Url.Combine(_urlBuilder.Root(), relativeImageUrl);
-
-        return WithImageUrl(imageUrl);
-    }
-
     public IOpenGraphBuilder WithImageUrl(string imageUrl) {
         _imageUrl = imageUrl;
 
         return this;
+    }
+
+    public IOpenGraphBuilder WithRelativeImageUrl(string relativeImageUrl) {
+        var imageUrl = Url.Combine(_urlBuilder.Root(), relativeImageUrl);
+
+        return WithImageUrl(imageUrl);
     }
 
     public IOpenGraphBuilder WithUrl(string url) {

--- a/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.cs
+++ b/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.cs
@@ -27,8 +27,8 @@ public class OpenGraphBuilder : IOpenGraphBuilder {
         return this;
     }
 
-    public IOpenGraphBuilder WithImagePath(string imagePath) {
-        var imageUrl = Url.Combine(_urlBuilder.Root(), imagePath);
+    public IOpenGraphBuilder WithRelativeImageUrl(string relativeImageUrl) {
+        var imageUrl = Url.Combine(_urlBuilder.Root(), relativeImageUrl);
 
         return WithImageUrl(imageUrl);
     }


### PR DESCRIPTION
## Linked work issue
https://github.com/n3oltd/work/issues/579

re n3oltd/work#

## Summary
What was broken



Blog thumbnails weren't showing up when you shared a URL on WhatsApp / LinkedIn — even though the title and description did.



Why



The og:image meta tag was being rendered with a broken URL:



/media/xxx/image.jpg%3Fwidth=1200&height=630&v=...

                     ↑↑↑

                     %3F = URL-encoded "?"



The ? character had been escaped to %3F, which glues the query string onto the filename. The browser then asks the media server for a file literally named image.jpg%3Fwidth=1200, which doesn't exist → 404 → no thumbnail

preview.



Root cause



In N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.cs, the code was joining the site's base URL with the image URL using Flurl's AppendPathSegment:



_urlBuilder.Root().AppendPathSegment(imagePath);



AppendPathSegment treats its input as one path segment and URL-encodes reserved characters like ? and &. That's correct behaviour if you're passing a filename — but the only caller passes an image URL that already contains a

query string (?width=1200&height=630&v=…) from GetCropUrl(...). Encoding the ? destroys the path/query boundary.



Fix



One-line change to use Url.Combine instead, which is URL-aware — it knows ? marks the start of the query string and leaves it alone:



Url.Combine(_urlBuilder.Root(), imagePath);



Safety



- WithImagePath has exactly one caller in the whole codebase (PageOpenGraphProvider.cs), and it always passes a path+query URL — so the old code was broken 100% of the time it ran.

- No production code depended on the broken encoding.

- Url.Combine handles both plain paths and path+query URLs correctly, so future callers won't hit the same trap.



Result



Rendered tag now:



  <meta property="og:image"

        content="https://site/media/xxx/image.jpg?width=1200&height=630&v=..." />



Which the media server actually serves → LinkedIn / WhatsApp / Facebook crawlers can fetch it → thumbnail appears on shared links.

## Test plan

- [ ]
