### PR TITLE
fix(cloud): image crop rect shape on the content/platforms wire (companion to backend#256)

### DIFF
--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Clients/ContentClient.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Clients/ContentClient.cs
@@ -386,11 +386,17 @@ namespace N3O.Umbraco.Cloud.Content.Clients
     public partial class ImageCropReq
     {
 
-        [Newtonsoft.Json.JsonProperty("bottomLeft", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public PointReq BottomLeft { get; set; }
+        [Newtonsoft.Json.JsonProperty("height", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? Height { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("topRight", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public PointReq TopRight { get; set; }
+        [Newtonsoft.Json.JsonProperty("width", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? Width { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("x", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? X { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("y", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? Y { get; set; }
 
     }
 

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Clients/PlatformsUmbracoClient.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Clients/PlatformsUmbracoClient.cs
@@ -1959,11 +1959,17 @@ namespace N3O.Umbraco.Cloud.Platforms.Clients
     public partial class ImageCropReq
     {
 
-        [Newtonsoft.Json.JsonProperty("bottomLeft", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public PointReq BottomLeft { get; set; }
+        [Newtonsoft.Json.JsonProperty("height", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? Height { get; set; }
 
-        [Newtonsoft.Json.JsonProperty("topRight", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public PointReq TopRight { get; set; }
+        [Newtonsoft.Json.JsonProperty("width", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? Width { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("x", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? X { get; set; }
+
+        [Newtonsoft.Json.JsonProperty("y", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? Y { get; set; }
 
     }
 

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/MediaWithCropsExtensions.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/MediaWithCropsExtensions.cs
@@ -20,14 +20,10 @@ public static class MediaWithCropsExtensions {
         
         req.Main = new ImageSimpleProcessingReq();
         req.Main.Crop = new ImageCropReq();
-        
-        req.Main.Crop.BottomLeft = new PointReq();
-        req.Main.Crop.BottomLeft.X = 0;
-        req.Main.Crop.BottomLeft.Y = 0;
-        
-        req.Main.Crop.TopRight = new PointReq();
-        req.Main.Crop.TopRight.X = (int) media.Properties.Single(x => x.Alias == MediaConstants.Width).GetValue();
-        req.Main.Crop.TopRight.Y = (int) media.Properties.Single(x => x.Alias == MediaConstants.Height).GetValue();
+        req.Main.Crop.X = 0;
+        req.Main.Crop.Y = 0;
+        req.Main.Crop.Width = (int) media.Properties.Single(x => x.Alias == MediaConstants.Width).GetValue();
+        req.Main.Crop.Height = (int) media.Properties.Single(x => x.Alias == MediaConstants.Height).GetValue();
 
         return req;
     }

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Offerings/PublishedOfferingMapping.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Offerings/PublishedOfferingMapping.cs
@@ -36,8 +36,8 @@ public class PublishedOfferingMapping : IMapDefinition {
         dest.FormContent.Image.Main = new PublishedProcessedImage();
         dest.FormContent.Image.Main.Url = new Uri(updateOfferingReq.FormContent.Image.SourceFile);
         dest.FormContent.Image.Main.Size = new PublishedSize();
-        dest.FormContent.Image.Main.Size.Width = updateOfferingReq.FormContent.Image.Main.Crop.TopRight.X;
-        dest.FormContent.Image.Main.Size.Height = updateOfferingReq.FormContent.Image.Main.Crop.BottomLeft.Y;
+        dest.FormContent.Image.Main.Size.Width = updateOfferingReq.FormContent.Image.Main.Crop.Width;
+        dest.FormContent.Image.Main.Size.Height = updateOfferingReq.FormContent.Image.Main.Crop.Height;
         
         dest.FormContent.Icon = new PublishedSvgContent();
         dest.FormContent.Icon.Url = new Uri(updateOfferingReq.FormContent.Icon.SourceFile);


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

Companion to n3oltd/backend#256, which retired the `bottomLeft`/`topRight` corner encoding for image crops (the values were top-left-origin cropper bounds under misnomer names) in favour of a rect — `x`/`y`/`width`/`height` — with **no wire backward compatibility**. This patches every place this repo speaks that wire to the backend content/platforms APIs:

- **Committed generated clients** (`ContentClient`, `PlatformsUmbracoClient`): the `ImageCropReq` model is hand-patched to the rect shape in the generated style. `clients/Generate-Clients.ps1` regenerates from beta swagger, which only serves the new shape once the backend deploys — re-running the script after that rollout reproduces exactly this.
- **`MediaWithCropsExtensions.ToImageSimpleContentReq`**: builds the full-image crop as `X=0, Y=0, Width/Height = media dimensions` instead of corner points.
- **`PublishedOfferingMapping`**: takes the published image size from `Crop.Width`/`Crop.Height` — which also fixes a pre-existing bug where `Size.Height` was read from `Crop.BottomLeft.Y`, which is always 0 for the full-image crops this repo produces.

Deliberately untouched, because they are Umbraco's own contracts rather than the backend wire: the Cropper plugin's `RectangleCropReq`/`CropperPropertyType` (Umbraco data-capture cropper — same misnomer family, its own API and backoffice consumers) and the Umbraco Crowdfunding plugin client (generated from this repo's own swagger). Flag if you want those modernised to the rect shape too — that's a separate contract change with its own consumers.

**Deploys together with n3oltd/backend#256** (content/crowdfunding/platforms — whose rollout also runs the stored-data rect datafixes).

## Test plan

- [x] `dotnet build src/Cloud/N3O.Umbraco.Cloud.Platforms` — green
- [x] Zero `BottomLeft`/`TopRight` references remain under `src/Cloud`
- [ ] After the coordinated deploy: publish a campaign/offering with imagery from Umbraco and confirm the content push succeeds and the published size is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
