### PR TITLE
Set Giving.Type and instantiate Scheduled options in campaign scheduled-giving mapping

### DIFF
--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/CreateCampaignReqMapping.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/CreateCampaignReqMapping.cs
@@ -39,6 +39,8 @@ public class CreateCampaignReqMapping : IMapDefinition {
             dest.Qurbani.End = LocalDatePattern.Iso.Format(src.Qurbani.EndAt.ToLocalDate());
         } else if (src.Type == CampaignTypes.ScheduledGiving) {
             dest.Giving = new ConnectGivingOptionsReq();
+            dest.Giving.Type = GivingType.Scheduled;
+            dest.Giving.Scheduled = new ConnectScheduledGivingOptionsReq();
             dest.Giving.Scheduled.ScheduleId = src.ScheduledGiving.Schedule.Id;
         } else if (src.Type == CampaignTypes.Telethon) {
             dest.Telethon = new TelethonCampaignOptionsReq();

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/UpdateCampaignReqMapping.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/UpdateCampaignReqMapping.cs
@@ -77,6 +77,8 @@ public class UpdateCampaignReqMapping : IMapDefinition {
             dest.Qurbani.End = LocalDatePattern.Iso.Format(src.Qurbani.EndAt.ToLocalDate());
         } else if (src.Type == CampaignTypes.ScheduledGiving) {
             dest.Giving = new ConnectGivingOptionsReq();
+            dest.Giving.Type = GivingType.Scheduled;
+            dest.Giving.Scheduled = new ConnectScheduledGivingOptionsReq();
             dest.Giving.Scheduled.ScheduleId = src.ScheduledGiving.Schedule.Id;
         } else if (src.Type == CampaignTypes.Telethon) {
             dest.Telethon = new TelethonCampaignOptionsReq();


### PR DESCRIPTION
@
no-work-issue

## Summary

Follow-up to the merged Connect giving mapping (#894). In the `ScheduledGiving` branch of both campaign mappings, set the giving type and instantiate the scheduled options object before assigning the schedule id:

```csharp
dest.Giving = new ConnectGivingOptionsReq();
dest.Giving.Type = GivingType.Scheduled;
dest.Giving.Scheduled = new ConnectScheduledGivingOptionsReq();
dest.Giving.Scheduled.ScheduleId = src.ScheduledGiving.Schedule.Id;
```

Applies to `CreateCampaignReqMapping` and `UpdateCampaignReqMapping`.

## Scope
2 files under `src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@