### PR TITLE
Add unified Giving campaign type (Regular and Scheduled)

### DIFF
--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Content/Campaigns/CampaignContent.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Content/Campaigns/CampaignContent.cs
@@ -17,7 +17,7 @@ namespace N3O.Umbraco.Cloud.Platforms.Content;
 [UmbracoContent(PlatformsConstants.Campaigns.CompositionAlias)]
 public class CampaignContent : UmbracoContent<CampaignContent> {
     private static readonly string QurbaniCampaignAlias = AliasHelper<QurbaniCampaignContent>.ContentTypeAlias();
-    private static readonly string ScheduledGivingCampaignAlias = AliasHelper<ScheduledGivingCampaignContent>.ContentTypeAlias();
+    private static readonly string GivingCampaignAlias = AliasHelper<GivingCampaignContent>.ContentTypeAlias();
     private static readonly string StandardCampaignAlias = AliasHelper<StandardCampaignContent>.ContentTypeAlias();
     private static readonly string TelethonCampaignAlias = AliasHelper<TelethonCampaignContent>.ContentTypeAlias();
     
@@ -33,9 +33,9 @@ public class CampaignContent : UmbracoContent<CampaignContent> {
         } else if (Type == CampaignTypes.Qurbani) {
             Qurbani = new QurbaniCampaignContent();
             Qurbani.SetContent(content);
-        } else if (Type == CampaignTypes.ScheduledGiving) {
-            ScheduledGiving = new ScheduledGivingCampaignContent();
-            ScheduledGiving.SetContent(content);
+        } else if (Type == CampaignTypes.Giving) {
+            Giving = new GivingCampaignContent();
+            Giving.SetContent(content);
         } else if (Type == CampaignTypes.Telethon) {
             Telethon = new TelethonCampaignContent();
             Telethon.SetContent(content);
@@ -62,7 +62,7 @@ public class CampaignContent : UmbracoContent<CampaignContent> {
         Qurbani?.SetVariationContext(variationContext);
         Standard?.SetVariationContext(variationContext);
         Telethon?.SetVariationContext(variationContext);
-        ScheduledGiving?.SetVariationContext(variationContext);
+        Giving?.SetVariationContext(variationContext);
     }
 
     public string Name => Content().Name;
@@ -83,7 +83,7 @@ public class CampaignContent : UmbracoContent<CampaignContent> {
     
     public DonationFormContentContent FormContent { get; private set; }
     public QurbaniCampaignContent Qurbani { get; private set; }
-    public ScheduledGivingCampaignContent ScheduledGiving { get; private set; }
+    public GivingCampaignContent Giving { get; private set; }
     public StandardCampaignContent Standard { get; private set; }
     public TelethonCampaignContent Telethon { get; private set; }
     
@@ -95,8 +95,8 @@ public class CampaignContent : UmbracoContent<CampaignContent> {
                 return CampaignTypes.Standard;
             } else if (Content().ContentType.Alias.EqualsInvariant(QurbaniCampaignAlias)) {
                 return CampaignTypes.Qurbani;
-            } else if (Content().ContentType.Alias.EqualsInvariant(ScheduledGivingCampaignAlias)) {
-                return CampaignTypes.ScheduledGiving;
+            } else if (Content().ContentType.CompositionAliases.Any(x => x.EqualsInvariant(GivingCampaignAlias))) {
+                return CampaignTypes.Giving;
             } else if (Content().ContentType.Alias.EqualsInvariant(TelethonCampaignAlias)) {
                 return CampaignTypes.Telethon;
             } else {

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Content/Campaigns/GivingCampaignContent.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Content/Campaigns/GivingCampaignContent.cs
@@ -1,0 +1,50 @@
+﻿using N3O.Umbraco.Attributes;
+using N3O.Umbraco.Cloud.Platforms.Clients;
+using N3O.Umbraco.Content;
+using N3O.Umbraco.Exceptions;
+using N3O.Umbraco.Extensions;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace N3O.Umbraco.Cloud.Platforms.Content;
+
+[UmbracoContent(PlatformsConstants.Campaigns.CompositionAlias)]
+public class GivingCampaignContent : UmbracoContent<GivingCampaignContent> {
+    private static readonly string ScheduledGivingCampaignAlias = AliasHelper<ScheduledGivingCampaignContent>.ContentTypeAlias();
+    private static readonly string RegularGivingCampaignAlias = AliasHelper<RegularGivingCampaignContent>.ContentTypeAlias();
+    
+    public override void SetContent(IPublishedContent content) {
+        base.SetContent(content);
+        
+        if (Type == GivingType.Regular) {
+            RegularGiving = new RegularGivingCampaignContent();
+            RegularGiving.SetContent(content);
+        } else if (Type == GivingType.Scheduled) {
+            ScheduledGiving = new ScheduledGivingCampaignContent();
+            ScheduledGiving.SetContent(content);
+        } else {
+            throw UnrecognisedValueException.For(Type);
+        }
+    }
+    
+    public override void SetVariationContext(VariationContext variationContext) {
+        base.SetVariationContext(variationContext);
+
+        RegularGiving?.SetVariationContext(variationContext);
+        ScheduledGiving?.SetVariationContext(variationContext);
+    }
+    
+    public ScheduledGivingCampaignContent ScheduledGiving { get; private set; }
+    public RegularGivingCampaignContent RegularGiving { get; private set; }
+    
+    public GivingType Type {
+        get {
+            if (Content().ContentType.Alias.EqualsInvariant(RegularGivingCampaignAlias)) {
+                return GivingType.Regular;
+            } else if (Content().ContentType.Alias.EqualsInvariant(ScheduledGivingCampaignAlias)) {
+                return GivingType.Scheduled;
+            } else {
+                throw UnrecognisedValueException.For(Content().ContentType.Alias);
+            }
+        }
+    }
+}

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Content/Campaigns/RegularGivingCampaignContent.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Content/Campaigns/RegularGivingCampaignContent.cs
@@ -1,0 +1,10 @@
+﻿using N3O.Umbraco.Attributes;
+using N3O.Umbraco.Content;
+using N3O.Umbraco.Giving.Allocations.Lookups;
+
+namespace N3O.Umbraco.Cloud.Platforms.Content;
+
+[UmbracoContent(PlatformsConstants.Campaigns.RegularGiving)]
+public class RegularGivingCampaignContent : UmbracoContent<RegularGivingCampaignContent> {
+    public RegularGivingFrequency RegularGivingFrequency => GetValue(x => x.RegularGivingFrequency);
+}

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Lookups/Campaigns/CampaignType.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Lookups/Campaigns/CampaignType.cs
@@ -8,7 +8,7 @@ public class CampaignType : NamedLookup {
 
 public class CampaignTypes : StaticLookupsCollection<CampaignType> {
     public static readonly CampaignType Qurbani = new("qurbani", "Qurbani");
-    public static readonly CampaignType ScheduledGiving = new("scheduledGiving", "Scheduled Giving");
+    public static readonly CampaignType Giving = new("giving", "Giving");
     public static readonly CampaignType Standard = new("standard", "Standard");
     public static readonly CampaignType Telethon = new("telethon", "Telethon");
 }

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/CreateCampaignReqMapping.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/CreateCampaignReqMapping.cs
@@ -37,11 +37,17 @@ public class CreateCampaignReqMapping : IMapDefinition {
             dest.Qurbani.SeasonId = activeSeason.Id;
             dest.Qurbani.Begin = LocalDatePattern.Iso.Format(src.Qurbani.BeginAt.ToLocalDate());
             dest.Qurbani.End = LocalDatePattern.Iso.Format(src.Qurbani.EndAt.ToLocalDate());
-        } else if (src.Type == CampaignTypes.ScheduledGiving) {
+        } else if (src.Type == CampaignTypes.Giving) {
             dest.Giving = new ConnectGivingOptionsReq();
-            dest.Giving.Type = GivingType.Scheduled;
-            dest.Giving.Scheduled = new ConnectScheduledGivingOptionsReq();
-            dest.Giving.Scheduled.ScheduleId = src.ScheduledGiving.Schedule.Id;
+            dest.Giving.Type = src.Giving.Type;
+            
+            if (src.Giving.Type == GivingType.Regular) {
+                dest.Giving.Regular = new ConnectRegularGivingOptionsReq();
+                dest.Giving.Regular.Frequency = src.Giving.RegularGiving.RegularGivingFrequency.ToEnum<RegularGivingFrequency>();
+            } else {
+                dest.Giving.Scheduled = new ConnectScheduledGivingOptionsReq();
+                dest.Giving.Scheduled.ScheduleId = src.Giving.ScheduledGiving.Schedule.Id;
+            }
         } else if (src.Type == CampaignTypes.Telethon) {
             dest.Telethon = new TelethonCampaignOptionsReq();
             dest.Telethon.Begin = src.Telethon.BeginAt.ToLocalDateTime().ToString("o", null);

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/CreateCampaignReqMapping.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/CreateCampaignReqMapping.cs
@@ -3,6 +3,7 @@ using N3O.Umbraco.Cloud.Lookups;
 using N3O.Umbraco.Cloud.Platforms.Clients;
 using N3O.Umbraco.Cloud.Platforms.Content;
 using N3O.Umbraco.Cloud.Platforms.Lookups;
+using N3O.Umbraco.Exceptions;
 using N3O.Umbraco.Extensions;
 using NodaTime.Extensions;
 using NodaTime.Text;
@@ -44,9 +45,11 @@ public class CreateCampaignReqMapping : IMapDefinition {
             if (src.Giving.Type == GivingType.Regular) {
                 dest.Giving.Regular = new ConnectRegularGivingOptionsReq();
                 dest.Giving.Regular.Frequency = src.Giving.RegularGiving.RegularGivingFrequency.ToEnum<RegularGivingFrequency>();
-            } else {
+            } else if (src.Giving.Type == GivingType.Scheduled) {
                 dest.Giving.Scheduled = new ConnectScheduledGivingOptionsReq();
                 dest.Giving.Scheduled.ScheduleId = src.Giving.ScheduledGiving.Schedule.Id;
+            } else {
+                throw UnrecognisedValueException.For(src.Giving.Type);
             }
         } else if (src.Type == CampaignTypes.Telethon) {
             dest.Telethon = new TelethonCampaignOptionsReq();

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/UpdateCampaignReqMapping.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/UpdateCampaignReqMapping.cs
@@ -4,6 +4,7 @@ using N3O.Umbraco.Cloud.Platforms.Clients;
 using N3O.Umbraco.Cloud.Platforms.Content;
 using N3O.Umbraco.Cloud.Platforms.Extensions;
 using N3O.Umbraco.Cloud.Platforms.Lookups;
+using N3O.Umbraco.Exceptions;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Media;
 using NodaTime.Extensions;
@@ -82,9 +83,11 @@ public class UpdateCampaignReqMapping : IMapDefinition {
             if (src.Giving.Type == GivingType.Regular) {
                 dest.Giving.Regular = new ConnectRegularGivingOptionsReq();
                 dest.Giving.Regular.Frequency = src.Giving.RegularGiving.RegularGivingFrequency.ToEnum<RegularGivingFrequency>();
-            } else {
+            } else if (src.Giving.Type == GivingType.Scheduled) {
                 dest.Giving.Scheduled = new ConnectScheduledGivingOptionsReq();
                 dest.Giving.Scheduled.ScheduleId = src.Giving.ScheduledGiving.Schedule.Id;
+            } else {
+                throw UnrecognisedValueException.For(src.Giving.Type);
             }
         } else if (src.Type == CampaignTypes.Telethon) {
             dest.Telethon = new TelethonCampaignOptionsReq();

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/UpdateCampaignReqMapping.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/Campaigns/UpdateCampaignReqMapping.cs
@@ -75,11 +75,17 @@ public class UpdateCampaignReqMapping : IMapDefinition {
             dest.Qurbani.SeasonId = activeSeason.Id;
             dest.Qurbani.Begin = LocalDatePattern.Iso.Format(src.Qurbani.BeginAt.ToLocalDate());
             dest.Qurbani.End = LocalDatePattern.Iso.Format(src.Qurbani.EndAt.ToLocalDate());
-        } else if (src.Type == CampaignTypes.ScheduledGiving) {
+        } else if (src.Type == CampaignTypes.Giving) {
             dest.Giving = new ConnectGivingOptionsReq();
-            dest.Giving.Type = GivingType.Scheduled;
-            dest.Giving.Scheduled = new ConnectScheduledGivingOptionsReq();
-            dest.Giving.Scheduled.ScheduleId = src.ScheduledGiving.Schedule.Id;
+            dest.Giving.Type = src.Giving.Type;
+            
+            if (src.Giving.Type == GivingType.Regular) {
+                dest.Giving.Regular = new ConnectRegularGivingOptionsReq();
+                dest.Giving.Regular.Frequency = src.Giving.RegularGiving.RegularGivingFrequency.ToEnum<RegularGivingFrequency>();
+            } else {
+                dest.Giving.Scheduled = new ConnectScheduledGivingOptionsReq();
+                dest.Giving.Scheduled.ScheduleId = src.Giving.ScheduledGiving.Schedule.Id;
+            }
         } else if (src.Type == CampaignTypes.Telethon) {
             dest.Telethon = new TelethonCampaignOptionsReq();
             

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/PlatformsConstants.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/PlatformsConstants.cs
@@ -7,9 +7,12 @@ public static class PlatformsConstants {
     public static class Campaigns {
         public const string CompositionAlias = "platformsCampaign";
         public const string Qurbani = "platformsQurbaniCampaign";
-        public const string ScheduledGiving = "platformsScheduledGivingCampaign";
+        public const string Giving = "platformsGivingCampaign";
         public const string Standard = "platformsStandardCampaign";
         public const string Telethon = "platformsTelethonCampaign";
+        
+        public const string ScheduledGiving = "platformsScheduledGivingCampaign";
+        public const string RegularGiving = "platformsRegularGivingCampaign";
     }
 
     public static class CrossSells {

--- a/src/Giving/N3O.Umbraco.Giving.Allocations/Lookups/RegularGivingFrequency.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Allocations/Lookups/RegularGivingFrequency.cs
@@ -1,7 +1,7 @@
 using N3O.Umbraco.Lookups;
 using NodaTime;
 
-namespace N3O.Umbraco.Giving.Checkout.Lookups;
+namespace N3O.Umbraco.Giving.Allocations.Lookups;
 
 public class RegularGivingFrequency : NamedLookup {
     public RegularGivingFrequency(string id, string name, int months) : base(id, name) {
@@ -19,4 +19,5 @@ public class RegularGivingFrequencies : StaticLookupsCollection<RegularGivingFre
     public static RegularGivingFrequency Annually = new("annually", "Annually", 12);
     public static RegularGivingFrequency Monthly = new("monthly", "Monthly", 1);
     public static RegularGivingFrequency Quarterly = new("quarterly", "Quarterly", 3);
+    public static RegularGivingFrequency Weekly = new ("weekly", "Weekly", 1);
 }

--- a/src/Giving/N3O.Umbraco.Giving.Allocations/Lookups/RegularGivingFrequencySource.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Allocations/Lookups/RegularGivingFrequencySource.cs
@@ -5,7 +5,7 @@ namespace N3O.Umbraco.Giving.Allocations.Lookups;
 public class RegularGivingFrequencySource : LookupsDataSource<RegularGivingFrequency> {
     public RegularGivingFrequencySource(ILookups lookups) : base(lookups) { }
     
-    public override string Name => "Regular Giving Collection Frequency";
+    public override string Name => "Regular Giving Frequency";
     public override string Description => "Data source for regular giving frequency";
     public override string Icon => "icon-calendar-alt";
 

--- a/src/Giving/N3O.Umbraco.Giving.Allocations/Lookups/RegularGivingFrequencySource.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Allocations/Lookups/RegularGivingFrequencySource.cs
@@ -1,0 +1,13 @@
+﻿using N3O.Umbraco.Lookups;
+
+namespace N3O.Umbraco.Giving.Allocations.Lookups;
+
+public class RegularGivingFrequencySource : LookupsDataSource<RegularGivingFrequency> {
+    public RegularGivingFrequencySource(ILookups lookups) : base(lookups) { }
+    
+    public override string Name => "Regular Giving Collection Frequency";
+    public override string Description => "Data source for regular giving frequency";
+    public override string Icon => "icon-calendar-alt";
+
+    protected override string GetIcon(RegularGivingFrequency regularGivingFrequency) => "icon-calendar-alt";
+}

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Lookups/CheckoutLookupTypes.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Lookups/CheckoutLookupTypes.cs
@@ -1,3 +1,4 @@
+using N3O.Umbraco.Giving.Allocations.Lookups;
 using N3O.Umbraco.Lookups;
 
 namespace N3O.Umbraco.Giving.Checkout.Lookups;

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Models/RegularGivingOptions/RegularGivingOptions.I.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Models/RegularGivingOptions/RegularGivingOptions.I.cs
@@ -1,4 +1,4 @@
-using N3O.Umbraco.Giving.Checkout.Lookups;
+using N3O.Umbraco.Giving.Allocations.Lookups;
 using N3O.Umbraco.Lookups;
 using NodaTime;
 

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Models/RegularGivingOptions/RegularGivingOptions.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Models/RegularGivingOptions/RegularGivingOptions.cs
@@ -1,4 +1,4 @@
-using N3O.Umbraco.Giving.Checkout.Lookups;
+using N3O.Umbraco.Giving.Allocations.Lookups;
 using N3O.Umbraco.Lookups;
 using Newtonsoft.Json;
 using NodaTime;

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Models/RegularGivingOptions/RegularGivingOptionsReq.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Models/RegularGivingOptions/RegularGivingOptionsReq.cs
@@ -1,5 +1,5 @@
 using N3O.Umbraco.Attributes;
-using N3O.Umbraco.Giving.Checkout.Lookups;
+using N3O.Umbraco.Giving.Allocations.Lookups;
 using N3O.Umbraco.Lookups;
 using NodaTime;
 

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Models/RegularGivingOptions/RegularGivingOptionsRes.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Models/RegularGivingOptions/RegularGivingOptionsRes.cs
@@ -1,4 +1,4 @@
-using N3O.Umbraco.Giving.Checkout.Lookups;
+using N3O.Umbraco.Giving.Allocations.Lookups;
 using N3O.Umbraco.Lookups;
 using NodaTime;
 


### PR DESCRIPTION
@
no-work-issue

## Summary

Replaces the `ScheduledGiving` campaign branch with a unified `Giving` campaign type that maps both Regular and Scheduled giving.

- **Mappings** (`CreateCampaignReqMapping`, `UpdateCampaignReqMapping`): branch on `src.Giving.Type` — `ConnectRegularGivingOptionsReq` (with frequency) or `ConnectScheduledGivingOptionsReq` (with schedule id).
- **Content:** new `GivingCampaignContent` and `RegularGivingCampaignContent`; `CampaignContent`, `CampaignType` and `PlatformsConstants` updated.
- **Lookups:** move `RegularGivingFrequency` to `Giving.Allocations` (new lookup + source), remove `RegularGivingCollectionFrequency`; update `Giving.Checkout` `RegularGivingOptions` models and `CheckoutLookupTypes`.

## Scope
15 files (shown as 14 — the RegularGivingFrequency move is detected as a rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@