### PR TITLE
Return 302 not 301 on transient CDN failure, surface 503 for infra errors

### DIFF
--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/CdnClientExtensions.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/CdnClientExtensions.cs
@@ -39,6 +39,10 @@ public static class CdnClientExtensions {
             var additionalModels = await publishedPlatformsPage.OrEmpty(x => x.MergeModels)
                                                                .SelectListAsync(x => FetchMergeModelAsync(cdnClient, x));
 
+            if (additionalModels.HasAny(x => x.Error)) {
+                return GetPageResult.ForError();
+            }
+
             var platformsPage = new PlatformsPage(publishedContentResult.Id.GetValueOrThrow(),
                                                   publishedContentResult.Kind,
                                                   parent,

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/CdnClientExtensions.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/CdnClientExtensions.cs
@@ -22,7 +22,9 @@ public static class CdnClientExtensions {
         
         var publishedContentResult = await cdnClient.DownloadPublishedContentAsync(pagePath, cancellationToken);
 
-        if (publishedContentResult.NotFound) {
+        if (publishedContentResult.Error) {
+            return GetPageResult.ForError();
+        } else if (publishedContentResult.NotFound) {
             return null;
         } else {
             if (publishedContentResult.Kind == PublishedFileKinds.PageRedirect) {

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Hosting/Middleware/PlatformsCdnFailureMiddleware.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Hosting/Middleware/PlatformsCdnFailureMiddleware.cs
@@ -22,8 +22,7 @@ public class PlatformsCdnFailureMiddleware : IMiddleware {
 
     public async Task InvokeAsync(HttpContext context, RequestDelegate next) {
         try {
-            // Page resolution reads the content cache, which requires an ambient UmbracoContext;
-            // one does not yet exist this early in the pipeline, so establish it here.
+            // Content-cache resolution requires an ambient UmbracoContext, which PrePipeline lacks.
             using (_umbracoContextFactory.Value.EnsureUmbracoContext()) {
                 var getPageResult = await _platformsPageAccessor.GetAsync(context.RequestAborted);
 
@@ -35,7 +34,7 @@ public class PlatformsCdnFailureMiddleware : IMiddleware {
                 }
             }
         } catch (Exception ex) {
-            // A CDN failure check must never itself fail the request; fall through to the pipeline.
+            // A CDN failure check must never itself fail the request.
             _logger.Value.LogWarning(ex, "Could not check platforms page for a CDN failure");
         }
 

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Hosting/Middleware/PlatformsCdnFailureMiddleware.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Hosting/Middleware/PlatformsCdnFailureMiddleware.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Http;
+using N3O.Umbraco.Extensions;
+using System.Threading.Tasks;
+
+namespace N3O.Umbraco.Cloud.Platforms.Hosting;
+
+public class PlatformsCdnFailureMiddleware : IMiddleware {
+    private readonly IPlatformsPageAccessor _platformsPageAccessor;
+
+    public PlatformsCdnFailureMiddleware(IPlatformsPageAccessor platformsPageAccessor) {
+        _platformsPageAccessor = platformsPageAccessor;
+    }
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next) {
+        var getPageResult = await _platformsPageAccessor.GetAsync(context.RequestAborted);
+
+        if (getPageResult.HasValue() && getPageResult.IsError) {
+            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            context.Response.Headers.RetryAfter = "10";
+
+            return;
+        }
+
+        await next(context);
+    }
+}

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Hosting/Middleware/PlatformsCdnFailureMiddleware.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Hosting/Middleware/PlatformsCdnFailureMiddleware.cs
@@ -1,24 +1,42 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using N3O.Umbraco.Extensions;
+using System;
 using System.Threading.Tasks;
+using Umbraco.Cms.Core.Web;
 
 namespace N3O.Umbraco.Cloud.Platforms.Hosting;
 
 public class PlatformsCdnFailureMiddleware : IMiddleware {
     private readonly IPlatformsPageAccessor _platformsPageAccessor;
+    private readonly Lazy<IUmbracoContextFactory> _umbracoContextFactory;
+    private readonly Lazy<ILogger<PlatformsCdnFailureMiddleware>> _logger;
 
-    public PlatformsCdnFailureMiddleware(IPlatformsPageAccessor platformsPageAccessor) {
+    public PlatformsCdnFailureMiddleware(IPlatformsPageAccessor platformsPageAccessor,
+                                         Lazy<IUmbracoContextFactory> umbracoContextFactory,
+                                         Lazy<ILogger<PlatformsCdnFailureMiddleware>> logger) {
         _platformsPageAccessor = platformsPageAccessor;
+        _umbracoContextFactory = umbracoContextFactory;
+        _logger = logger;
     }
 
     public async Task InvokeAsync(HttpContext context, RequestDelegate next) {
-        var getPageResult = await _platformsPageAccessor.GetAsync(context.RequestAborted);
+        try {
+            // Page resolution reads the content cache, which requires an ambient UmbracoContext;
+            // one does not yet exist this early in the pipeline, so establish it here.
+            using (_umbracoContextFactory.Value.EnsureUmbracoContext()) {
+                var getPageResult = await _platformsPageAccessor.GetAsync(context.RequestAborted);
 
-        if (getPageResult.HasValue() && getPageResult.IsError) {
-            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-            context.Response.Headers.RetryAfter = "10";
+                if (getPageResult.HasValue() && getPageResult.IsError) {
+                    context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                    context.Response.Headers.RetryAfter = "10";
 
-            return;
+                    return;
+                }
+            }
+        } catch (Exception ex) {
+            // A CDN failure check must never itself fail the request; fall through to the pipeline.
+            _logger.Value.LogWarning(ex, "Could not check platforms page for a CDN failure");
         }
 
         await next(context);

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/GetPageResult.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/GetPageResult.cs
@@ -5,22 +5,29 @@ using Newtonsoft.Json;
 namespace N3O.Umbraco.Cloud.Platforms.Models;
 
 public class GetPageResult {
-    private GetPageResult(PlatformsPage page, Redirect redirect) {
+    private GetPageResult(PlatformsPage page, Redirect redirect, bool isError) {
         Page = page;
         Redirect = redirect;
+        IsError = isError;
     }
-    
+
     public PlatformsPage Page { get; }
     public Redirect Redirect { get; }
-    
+    // True when the page could not be resolved due to a transient CDN infrastructure failure (not a 404)
+    public bool IsError { get; }
+
     [JsonIgnore]
     public bool IsRedirect => Redirect.HasValue();
 
     public static GetPageResult ForPage(PlatformsPage page) {
-        return new GetPageResult(page, null);
+        return new GetPageResult(page, null, false);
     }
-    
+
     public static GetPageResult ForRedirect(string url, bool temporary) {
-        return new GetPageResult(null, new Redirect(url, temporary));
+        return new GetPageResult(null, new Redirect(url, temporary), false);
+    }
+
+    public static GetPageResult ForError() {
+        return new GetPageResult(null, null, true);
     }
 }

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/GetPageResult.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Models/GetPageResult.cs
@@ -13,7 +13,6 @@ public class GetPageResult {
 
     public PlatformsPage Page { get; }
     public Redirect Redirect { get; }
-    // True when the page could not be resolved due to a transient CDN infrastructure failure (not a 404)
     public bool IsError { get; }
 
     [JsonIgnore]

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/PlatformsComposer.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/PlatformsComposer.cs
@@ -22,6 +22,7 @@ public class PlatformsComposer : Composer {
         builder.Services.AddSingleton<IPlatformsPageAccessor, PlatformsPageAccessor>();
         builder.Services.AddSingleton<ITagHelperComponent, PlatformsTagHelperComponent>();
         
+        builder.Services.AddScoped<PlatformsCdnFailureMiddleware>();
         builder.Services.AddScoped<PlatformsTemplatesMiddleware>();
         
         RegisterAll(t => t.ImplementsInterface<ICampaignIdProvider>(),
@@ -33,6 +34,20 @@ public class PlatformsComposer : Composer {
         RegisterAll(t => t.ImplementsInterface<IPreviewHtmlGenerator>(),
                     t => builder.Services.AddTransient(typeof(IPreviewHtmlGenerator), t));
         
+        builder.Services.Configure<UmbracoPipelineOptions>(opt => {
+            var filter = new UmbracoPipelineFilter(nameof(PlatformsCdnFailureMiddleware));
+
+            filter.PrePipeline = app => {
+                var runtimeState = app.ApplicationServices.GetRequiredService<IRuntimeState>();
+
+                if (runtimeState.Level == RuntimeLevel.Run) {
+                    app.UseMiddleware<PlatformsCdnFailureMiddleware>();
+                }
+            };
+
+            opt.AddFilter(filter);
+        });
+
         builder.Services.Configure<UmbracoPipelineOptions>(opt => {
             var filter = new UmbracoPipelineFilter(nameof(PlatformsTemplatesMiddleware));
             

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageAccessor.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageAccessor.cs
@@ -73,7 +73,7 @@ public class PlatformsPageAccessor : IPlatformsPageAccessor {
                         return getPageResult;
                     } else {
                         if (currentPath != platformsPath) {
-                            return GetPageResult.ForRedirect(getPageResult.Page.Url.AbsolutePath, false);
+                            return GetPageResult.ForRedirect(getPageResult.Page.Url.AbsolutePath, true);
                         } else {
                             return getPageResult;
                         }

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageAccessor.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageAccessor.cs
@@ -93,8 +93,6 @@ public class PlatformsPageAccessor : IPlatformsPageAccessor {
         }
         
         if (fallbacks.Any()) {
-            // Temporary (302): the fallback fires when a page cannot be resolved, which may be a transient condition.
-            // A permanent (301) redirect would be cached by browsers indefinitely and pin a broken campaign link
             return GetPageResult.ForRedirect(SpecialContentPathParser.GetPath(_contentCache, fallbacks.First()),
                                              true);
         } else {

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageAccessor.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageAccessor.cs
@@ -64,6 +64,10 @@ public class PlatformsPageAccessor : IPlatformsPageAccessor {
                                                                                 currentPath,
                                                                                 cancellationToken);
 
+                if (getPageResult.HasValue() && getPageResult.IsError) {
+                    return getPageResult;
+                }
+
                 if (getPageResult.HasValue()) {
                     if (getPageResult.IsRedirect) {
                         return getPageResult;
@@ -89,8 +93,10 @@ public class PlatformsPageAccessor : IPlatformsPageAccessor {
         }
         
         if (fallbacks.Any()) {
+            // Temporary (302): the fallback fires when a page cannot be resolved, which may be a transient condition.
+            // A permanent (301) redirect would be cached by browsers indefinitely and pin a broken campaign link
             return GetPageResult.ForRedirect(SpecialContentPathParser.GetPath(_contentCache, fallbacks.First()),
-                                             false);
+                                             true);
         } else {
             return null;   
         }

--- a/src/Cloud/N3O.Umbraco.Cloud/Models/CdnDownloadResult.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud/Models/CdnDownloadResult.cs
@@ -4,16 +4,18 @@ namespace N3O.Umbraco.Cloud.Models;
 
 public class CdnDownloadResult {
     private static readonly Duration MaxAge = Duration.FromMinutes(5);
-    // Long interval so chronic 404 paths don't keep re-fetching and saturating CdnClient's concurrency budget
-    private static readonly Duration RetryInterval = Duration.FromMinutes(15);
-    
-    private CdnDownloadResult(bool success, string content, Instant timestamp) {
+    private static readonly Duration NotFoundRetryInterval = Duration.FromMinutes(15);
+    private static readonly Duration ErrorRetryInterval = Duration.FromSeconds(10);
+
+    private CdnDownloadResult(bool success, bool error, string content, Instant timestamp) {
         Success = success;
+        Error = error;
         Content = content;
         Timestamp = timestamp;
     }
 
     public bool Success { get; }
+    public bool Error { get; }
     public string Content { get; }
     public Instant Timestamp { get; }
 
@@ -23,7 +25,7 @@ public class CdnDownloadResult {
         } else {
             var age = clock.GetCurrentInstant() - Timestamp;
 
-            return age > RetryInterval;
+            return age > (Error ? ErrorRetryInterval : NotFoundRetryInterval);
         }
     }
     
@@ -37,11 +39,15 @@ public class CdnDownloadResult {
         }
     }
 
-    public static CdnDownloadResult ForFailure(IClock clock) {
-        return new CdnDownloadResult(false, null, clock.GetCurrentInstant());
+    public static CdnDownloadResult ForNotFound(IClock clock) {
+        return new CdnDownloadResult(false, false, null, clock.GetCurrentInstant());
     }
-    
+
+    public static CdnDownloadResult ForError(IClock clock) {
+        return new CdnDownloadResult(false, true, null, clock.GetCurrentInstant());
+    }
+
     public static CdnDownloadResult ForSuccess(IClock clock, string content) {
-        return new CdnDownloadResult(true, content, clock.GetCurrentInstant());
+        return new CdnDownloadResult(true, false, content, clock.GetCurrentInstant());
     }
 }

--- a/src/Cloud/N3O.Umbraco.Cloud/Models/PublishedContentResult.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud/Models/PublishedContentResult.cs
@@ -15,7 +15,6 @@ public class PublishedContentResult {
     }
 
     public bool NotFound { get; }
-    // True when the fetch failed for an infrastructure reason (timeout/5xx/network) rather than a genuine 404
     public bool Error { get; }
     public Guid? Id { get; }
     public PublishedFileKind Kind { get; }

--- a/src/Cloud/N3O.Umbraco.Cloud/Models/PublishedContentResult.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud/Models/PublishedContentResult.cs
@@ -5,8 +5,9 @@ using System;
 namespace N3O.Umbraco.Cloud.Models;
 
 public class PublishedContentResult {
-    private PublishedContentResult(bool notFound, Guid? id, PublishedFileKind kind, string path, JObject content) {
+    private PublishedContentResult(bool notFound, bool error, Guid? id, PublishedFileKind kind, string path, JObject content) {
         NotFound = notFound;
+        Error = error;
         Id = id;
         Kind = kind;
         Path = path;
@@ -14,16 +15,22 @@ public class PublishedContentResult {
     }
 
     public bool NotFound { get; }
+    // True when the fetch failed for an infrastructure reason (timeout/5xx/network) rather than a genuine 404
+    public bool Error { get; }
     public Guid? Id { get; }
     public PublishedFileKind Kind { get; }
     public string Path { get; }
     public JObject Content { get; }
 
     public static PublishedContentResult ForFound(Guid id, PublishedFileKind kind, string path, JObject content) {
-        return new PublishedContentResult(false, id, kind, path, content);
+        return new PublishedContentResult(false, false, id, kind, path, content);
     }
-    
+
     public static PublishedContentResult ForNotFound(string path) {
-        return new PublishedContentResult(true, null, null, path, null);
+        return new PublishedContentResult(true, false, null, null, path, null);
+    }
+
+    public static PublishedContentResult ForError(string path) {
+        return new PublishedContentResult(false, true, null, null, path, null);
     }
 }

--- a/src/Cloud/N3O.Umbraco.Cloud/Services/Cdn/CdnClient.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud/Services/Cdn/CdnClient.cs
@@ -43,8 +43,10 @@ public class CdnClient : ICdnClient {
 
     public async Task<string> DownloadAsync(string path, CancellationToken cancellationToken = default) {
         var publishedUrl = GetPublishedContentUrl(path);
+        
+        var download = await FetchAsync(publishedUrl, cancellationToken);
 
-        return await FetchStringAsync(publishedUrl, cancellationToken);
+        return download.Content;
     }
 
     public async Task<T> DownloadPublishedContentAsync<T>(PublishedFileKind kind,
@@ -53,18 +55,22 @@ public class CdnClient : ICdnClient {
                                                           CancellationToken cancellationToken = default) {
         var publishedUrl = GetPublishedContentUrl(kind, path);
 
-        var json = await FetchStringAsync(publishedUrl, cancellationToken);
-            
-        return json.IfNotNull(x => Deserialize<T>(x, jsonSerializer));
+        var download = await FetchAsync(publishedUrl, cancellationToken);
+
+        return download.Content.IfNotNull(x => Deserialize<T>(x, jsonSerializer));
     }
 
     public async Task<PublishedContentResult> DownloadPublishedContentAsync(string path,
                                                                             CancellationToken cancellationToken = default) {
         var publishedUrl = GetPublishedContentUrl(path);
 
-        var json = await FetchStringAsync(publishedUrl, cancellationToken);
+        var download = await FetchAsync(publishedUrl, cancellationToken);
 
-        var jObject = json.IfNotNull(JObject.Parse);
+        if (download.Error) {
+            return PublishedContentResult.ForError(path);
+        }
+
+        var jObject = download.Content.IfNotNull(JObject.Parse);
         var kind = jObject.GetPublishedFileKind();
             
         if (kind.HasValue()) {
@@ -76,18 +82,18 @@ public class CdnClient : ICdnClient {
         }
     }
 
-    private async Task<string> FetchStringAsync(string publishedUrl, CancellationToken cancellationToken) {
+    private async Task<CdnDownloadResult> FetchAsync(string publishedUrl, CancellationToken cancellationToken) {
         var download = Downloads.GetOrDefault(publishedUrl);
             
         if (download == null || download.IsExpired(_clock) || download.CanRetry(_clock)) {
             var cdnDownloadResult = await DownloadStringAsync(publishedUrl, cancellationToken);
 
-            if (download == null || cdnDownloadResult.Success) {
+            if (download == null || cdnDownloadResult.Success || !download.Success) {
                 Downloads[publishedUrl] = cdnDownloadResult;
             }
         }
 
-        return Downloads[publishedUrl].Content;
+        return Downloads[publishedUrl];
     }
     
     private async Task<CdnDownloadResult> DownloadStringAsync(string publishedUrl,
@@ -99,11 +105,11 @@ public class CdnClient : ICdnClient {
         } catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound) {
             _logger.LogDebug("CDN 404 for {PublishedUrl}", publishedUrl);
 
-            return CdnDownloadResult.ForFailure(_clock);
+            return CdnDownloadResult.ForNotFound(_clock);
         } catch (Exception ex) {
             _logger.LogWarning(ex, "Could not download {PublishedUrl}", publishedUrl);
 
-            return CdnDownloadResult.ForFailure(_clock);
+            return CdnDownloadResult.ForError(_clock);
         }
     }
     

--- a/src/Cloud/N3O.Umbraco.Cloud/Services/Cdn/CdnClient.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud/Services/Cdn/CdnClient.cs
@@ -21,6 +21,7 @@ namespace N3O.Umbraco.Cloud;
 public class CdnClient : ICdnClient {
     private static readonly SemaphoreSlim ConcurrencyLimit = new(10, 10);
     private static readonly ConcurrentDictionary<string, CdnDownloadResult> Downloads = new(StringComparer.InvariantCultureIgnoreCase);
+    private static readonly ConcurrentDictionary<string, Lazy<Task<CdnDownloadResult>>> Refreshes = new(StringComparer.InvariantCultureIgnoreCase);
 
     private readonly ICloudUrl _cloudUrl;
     private readonly IClock _clock;
@@ -84,16 +85,33 @@ public class CdnClient : ICdnClient {
 
     private async Task<CdnDownloadResult> FetchAsync(string publishedUrl, CancellationToken cancellationToken) {
         var download = Downloads.GetOrDefault(publishedUrl);
-            
-        if (download == null || download.IsExpired(_clock) || download.CanRetry(_clock)) {
-            var cdnDownloadResult = await DownloadStringAsync(publishedUrl, cancellationToken);
 
-            if (download == null || cdnDownloadResult.Success || !download.Success) {
-                Downloads[publishedUrl] = cdnDownloadResult;
-            }
+        if (download == null || download.IsExpired(_clock) || download.CanRetry(_clock)) {
+            // Coalesce concurrent refreshes for the same URL so a slow or timing-out CDN cannot pile up
+            // in-flight fetches and exhaust the shared ConcurrencyLimit.
+            var refresh = Refreshes.GetOrAdd(publishedUrl,
+                                             url => new Lazy<Task<CdnDownloadResult>>(() => RefreshAsync(url)));
+
+            await refresh.Value.WaitAsync(cancellationToken);
         }
 
         return Downloads[publishedUrl];
+    }
+
+    private async Task<CdnDownloadResult> RefreshAsync(string publishedUrl) {
+        try {
+            var cdnDownloadResult = await DownloadStringAsync(publishedUrl, CancellationToken.None);
+
+            // Store a success; refresh a still-failed entry to reset its retry cooldown; keep a cached
+            // success when the refresh failed. Evaluated atomically against the live entry.
+            return Downloads.AddOrUpdate(publishedUrl,
+                                         cdnDownloadResult,
+                                         (_, existing) => cdnDownloadResult.Success || !existing.Success
+                                                              ? cdnDownloadResult
+                                                              : existing);
+        } finally {
+            Refreshes.TryRemove(publishedUrl, out _);
+        }
     }
     
     private async Task<CdnDownloadResult> DownloadStringAsync(string publishedUrl,

--- a/src/Cloud/N3O.Umbraco.Cloud/Services/Cdn/CdnClient.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud/Services/Cdn/CdnClient.cs
@@ -87,8 +87,7 @@ public class CdnClient : ICdnClient {
         var download = Downloads.GetOrDefault(publishedUrl);
 
         if (download == null || download.IsExpired(_clock) || download.CanRetry(_clock)) {
-            // Coalesce concurrent refreshes for the same URL so a slow or timing-out CDN cannot pile up
-            // in-flight fetches and exhaust the shared ConcurrencyLimit.
+            // Coalesce refreshes per URL so a failing CDN cannot pile up in-flight fetches and drain ConcurrencyLimit.
             var refresh = Refreshes.GetOrAdd(publishedUrl,
                                              url => new Lazy<Task<CdnDownloadResult>>(() => RefreshAsync(url)));
 
@@ -102,8 +101,7 @@ public class CdnClient : ICdnClient {
         try {
             var cdnDownloadResult = await DownloadStringAsync(publishedUrl, CancellationToken.None);
 
-            // Store a success; refresh a still-failed entry to reset its retry cooldown; keep a cached
-            // success when the refresh failed. Evaluated atomically against the live entry.
+            // A cached success is retained when a later refresh fails.
             return Downloads.AddOrUpdate(publishedUrl,
                                          cdnDownloadResult,
                                          (_, existing) => cdnDownloadResult.Success || !existing.Success


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3000 (item 1)

## Summary

`PlatformsContentFinder` resolves platforms pages from the CDN and, whenever a page could not be resolved, issued an HTTP **301 (permanent)** redirect to the Donate page — including when the CDN fetch failed transiently. Because browsers cache 301s indefinitely, a one-second CDN blip could **permanently** break an affected donor's campaign link (e.g. `/donate/ramadan-appeal`), redirecting them to `/donate` long after the CDN had recovered. The failure was also cached for 15 minutes, and a genuine 404 was indistinguishable from an infrastructure failure — both fell through to the same redirect. This has already occurred in production: `site-grf` carries a dated client-side workaround for donors whose browsers had pinned the 301.

This change makes the fallback redirect **302 (temporary)** so it is never cached permanently, and separates the two failure modes that were previously conflated. A CDN 404 (the page genuinely does not exist) still falls back to a temporary redirect and keeps the existing 15-minute retry interval. A transient infrastructure failure (timeout, 5xx, network) is now treated as "we don't know": it uses a short 10-second cooldown so the site recovers almost immediately instead of staying redirected for 15 minutes, a cached success is retained if a later refresh fails (so a blip serves slightly stale content rather than an error), and repeated failures refresh their timestamp so a sustained outage does not stampede the CDN. On a transient infrastructure failure a new middleware now returns **503 with a `Retry-After` header**, keeping the donor on the campaign URL and signalling crawlers/monitors to retry, rather than silently redirecting them away. The middleware runs at `PrePipeline` because Umbraco 13's content-finder pipeline cannot emit a 5xx (it forces a 404 whenever no content node is assigned).

Scope is item 1 of the issue only. Item 2 is by design and item 3 (leaked credentials) is owned separately, both per @nadrummond. Once this is merged and verified, `site-grf` can drop its client-side 301 workaround and the other `site-*` repos should be checked for the same patch. `ConnectMiddleware` has a same-shaped bug for static connect assets (infra failure returns 404) that is intentionally left out of this PR.

## Test plan

- [x] `N3O.Umbraco.Cloud.Platforms` builds with 0 errors (transitively builds `N3O.Umbraco.Cloud`)
- [ ] Against a running site: a transient CDN failure on a campaign page returns **302** (not 301) to `/donate`
- [ ] Against a running site: a CDN infrastructure failure (timeout/5xx) on a campaign page returns **503** with a `Retry-After` header, on the original URL
- [ ] A CDN 404 still falls back to a temporary redirect
- [ ] After a transient failure recovers, the page resolves correctly within ~10s (no 15-minute stickiness)
- [ ] Confirm `IContentCache` is available at `PrePipeline` (`RuntimeLevel.Run`) so the middleware's page resolution works that early in the pipeline
