### PR TITLE
Protect donor data on checkout pages: no-store + HTML-safe analytics scripts (work#3002)

### DIFF
--- a/src/Analytics/N3O.Umbraco.Analytics/Services/DataLayerBuilder/DataLayerBuilder.cs
+++ b/src/Analytics/N3O.Umbraco.Analytics/Services/DataLayerBuilder/DataLayerBuilder.cs
@@ -17,7 +17,7 @@ public class DataLayerBuilder : IDataLayerBuilder {
         var javaScript = new StringBuilder();
 
         foreach (var obj in toPush.OrEmpty()) {
-            var json = _jsonProvider.SerializeObject(obj);
+            var json = _jsonProvider.SerializeObjectForScript(obj);
             
             javaScript.AppendLine($"window.dataLayer.push({json});");
             javaScript.AppendLine();

--- a/src/Analytics/N3O.Umbraco.Analytics/TagHelpers/EventTagHelper.cs
+++ b/src/Analytics/N3O.Umbraco.Analytics/TagHelpers/EventTagHelper.cs
@@ -21,7 +21,7 @@ public abstract class EventTagHelper : TagHelper {
             output.TagName = null;
 
             var parameters = await GetParametersAsync();
-            var parametersJson = _jsonProvider.SerializeObject(parameters);
+            var parametersJson = _jsonProvider.SerializeObjectForScript(parameters);
             
             var scriptTag = new TagBuilder("script");
 

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Controllers/CheckoutStagePageController.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Controllers/CheckoutStagePageController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.Extensions.Logging;
+using N3O.Umbraco.Constants;
 using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Giving.Checkout.Content;
@@ -17,6 +18,7 @@ using Umbraco.Cms.Core.Web;
 
 namespace N3O.Umbraco.Giving.Checkout.Controllers;
 
+[ResponseCache(CacheProfileName = CacheProfiles.NoCache)]
 public abstract class CheckoutStagePageController : PageController {
     private static readonly string CompletePageAlias = AliasHelper<CheckoutCompletePageContent>.ContentTypeAlias();
     

--- a/src/N3O.Umbraco.Extensions/Json/JsonProvider.I.cs
+++ b/src/N3O.Umbraco.Extensions/Json/JsonProvider.I.cs
@@ -19,4 +19,5 @@ public interface IJsonProvider {
     JsonSerializerSettings GetSettings();
     string SerializeObject(object value, Formatting formatting = Formatting.Indented);
     void SerializeObject(JsonWriter writer, object value, Formatting formatting = Formatting.Indented);
+    string SerializeObjectForScript(object value, Formatting formatting = Formatting.Indented);
 }

--- a/src/N3O.Umbraco.Extensions/Json/JsonProvider.cs
+++ b/src/N3O.Umbraco.Extensions/Json/JsonProvider.cs
@@ -119,4 +119,13 @@ public class JsonProvider<TContractResolver> : IJsonProvider where TContractReso
 
         serializer.Serialize(writer, value);
     }
+
+    public string SerializeObjectForScript(object value, Formatting formatting = Formatting.Indented) {
+        var settings = GetSettings();
+
+        settings.Formatting = formatting;
+        settings.StringEscapeHandling = StringEscapeHandling.EscapeHtml;
+
+        return JsonConvert.SerializeObject(value, settings);
+    }
 }


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3002

## Summary

Two coupled protections for donor data on server-rendered checkout pages, from the audit in work#3002.

Checkout stage pages (account, donation, regular giving, complete) previously set no cache headers, so nothing in code stopped a shared/CDN cache from storing a page that carries donor-specific checkout data. This adds `[ResponseCache(CacheProfileName = CacheProfiles.NoCache)]` to `CheckoutStagePageController`, so every checkout stage page emits `no-store`. The attribute is inherited by all the concrete stage controllers, the header is set before the view renders, and it applies in every environment — mirroring how `ApiController` already protects API responses with the same profile.

Separately, the data layer and analytics event tag helpers serialize objects straight into inline `<script>` blocks using the default JSON string escaping, which does not escape `<` / `>`. A donor-entered field (for example a postcode) containing `</script>…` could therefore close the script tag and inject markup. This adds `IJsonProvider.SerializeObjectForScript`, identical to `SerializeObject` but with `StringEscapeHandling.EscapeHtml`, and switches `DataLayerBuilder` and `EventTagHelper` to it. The global JSON serialization default is left unchanged, so only the two paths that embed JSON into inline HTML scripts are affected.

## Test plan

- [ ] On a checkout stage page (account / donation / regular-giving / complete), assert the response carries `Cache-Control: no-store`
- [ ] Assert a normal content page does not get `no-store`
- [ ] Enter a checkout account field value containing `</script>` and confirm it renders HTML-escaped (e.g. `</script`) inside the data layer / purchase-event script, not as a literal closing tag
- [ ] Confirm the data layer / purchase-event JSON still parses and analytics fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)
