### PR TITLE
Overwrite existing blob in AzureStorageFolder.AddFileAsync (idempotent uploads)

### DIFF
--- a/src/Storage/N3O.Umbraco.Storage.Azure/Services/AzureStorageFolder.cs
+++ b/src/Storage/N3O.Umbraco.Storage.Azure/Services/AzureStorageFolder.cs
@@ -18,7 +18,9 @@ public class AzureStorageFolder : IStorageFolder {
     }
     
     public async Task AddFileAsync(string filename, Stream stream) {
-        await _container.UploadBlobAsync(GetBlobName(filename), stream);
+        var blobClient = _container.GetBlobClient(GetBlobName(filename));
+
+        await blobClient.UploadAsync(stream, overwrite: true);
     }
 
     public async Task AddFileAsync(string name, byte[] contents) {


### PR DESCRIPTION
## Why

`AzureStorageFolder.AddFileAsync` uploads via `BlobContainerClient.UploadBlobAsync`, which **creates only** — it throws `BlobAlreadyExists` (HTTP 409) if the blob already exists. So any re-sync or retry of a file that's already in storage fails ("The specified blob already exists" — seen on media ingestion in Headless).

## What

Upload through `BlobClient.UploadAsync(stream, overwrite: true)` so re-adding an existing file replaces it. The operation becomes idempotent; the `byte[]` overload delegates here so it's covered too.

re n3oltd/work#2794

🤖 Generated with [Claude Code](https://claude.com/claude-code)