### PR TITLE
Make scheduler worker count and job timeout configurable via SchedulerSettings

### DIFF
--- a/src/Scheduler/N3O.Umbraco.Scheduler/SchedulerComposer.cs
+++ b/src/Scheduler/N3O.Umbraco.Scheduler/SchedulerComposer.cs
@@ -34,6 +34,10 @@ public class SchedulerComposer : IComposer {
         builder.Services.AddSingleton<IJobUrlProvider, JobUrlProvider>();
         builder.Services.AddTransient<IBackgroundJob, BackgroundJob>();
         
+        var settings = builder.Config.GetSection(SchedulerSettings.SectionName).Get<SchedulerSettings>() ??
+                       new SchedulerSettings();
+        builder.Services.AddSingleton(settings);
+
         var connectionString = builder.Config.GetConnectionString(UmbracoConstants.System.UmbracoConnectionName);
 
         if (connectionString.HasValue()) {
@@ -55,21 +59,16 @@ public class SchedulerComposer : IComposer {
                    .UseMaxLinesInExceptionDetails(200);
             });
             
-            var defaultWorkerCount = builder.Config.GetValue<int?>(SchedulerConstants.Config.DefaultWorkerCount) ??
-                                     SchedulerConstants.Defaults.WorkerCount;
-            var longJobsWorkerCount = builder.Config.GetValue<int?>(SchedulerConstants.Config.LongJobsWorkerCount) ??
-                                      SchedulerConstants.Defaults.WorkerCount;
-
             builder.Services.AddHangfireServer(opt => {
                 opt.ServerName = SchedulerConstants.Workers.DefaultWorker;
                 opt.Queues = [SchedulerConstants.Queues.Default];
-                opt.WorkerCount = defaultWorkerCount;
+                opt.WorkerCount = settings.DefaultWorkerCount;
             });
 
             builder.Services.AddHangfireServer(opt => {
                 opt.ServerName = SchedulerConstants.Workers.LongJobsWorker;
                 opt.Queues = [SchedulerConstants.Queues.LongJobs];
-                opt.WorkerCount = longJobsWorkerCount;
+                opt.WorkerCount = settings.LongJobsWorkerCount;
             });
 
             AddAuthorizedUmbracoDashboard(builder);

--- a/src/Scheduler/N3O.Umbraco.Scheduler/SchedulerComposer.cs
+++ b/src/Scheduler/N3O.Umbraco.Scheduler/SchedulerComposer.cs
@@ -55,16 +55,21 @@ public class SchedulerComposer : IComposer {
                    .UseMaxLinesInExceptionDetails(200);
             });
             
+            var defaultWorkerCount = builder.Config.GetValue<int?>(SchedulerConstants.Config.DefaultWorkerCount) ??
+                                     SchedulerConstants.Defaults.WorkerCount;
+            var longJobsWorkerCount = builder.Config.GetValue<int?>(SchedulerConstants.Config.LongJobsWorkerCount) ??
+                                      SchedulerConstants.Defaults.WorkerCount;
+
             builder.Services.AddHangfireServer(opt => {
                 opt.ServerName = SchedulerConstants.Workers.DefaultWorker;
                 opt.Queues = [SchedulerConstants.Queues.Default];
-                opt.WorkerCount = 1;
+                opt.WorkerCount = defaultWorkerCount;
             });
 
             builder.Services.AddHangfireServer(opt => {
                 opt.ServerName = SchedulerConstants.Workers.LongJobsWorker;
                 opt.Queues = [SchedulerConstants.Queues.LongJobs];
-                opt.WorkerCount = 1;
+                opt.WorkerCount = longJobsWorkerCount;
             });
 
             AddAuthorizedUmbracoDashboard(builder);

--- a/src/Scheduler/N3O.Umbraco.Scheduler/SchedulerConstants.cs
+++ b/src/Scheduler/N3O.Umbraco.Scheduler/SchedulerConstants.cs
@@ -1,6 +1,17 @@
 ﻿namespace N3O.Umbraco.Scheduler;
 
 public static class SchedulerConstants {
+    public static class Config {
+        public const string DefaultWorkerCount = "N3O:Scheduler:DefaultWorkerCount";
+        public const string LongJobsWorkerCount = "N3O:Scheduler:LongJobsWorkerCount";
+        public const string JobTimeoutMinutes = "N3O:Scheduler:JobTimeoutMinutes";
+    }
+
+    public static class Defaults {
+        public const int WorkerCount = 1;
+        public const int JobTimeoutMinutes = 30;
+    }
+
     public static class Parameters {
         public const string Culture = "culture";
     }

--- a/src/Scheduler/N3O.Umbraco.Scheduler/SchedulerConstants.cs
+++ b/src/Scheduler/N3O.Umbraco.Scheduler/SchedulerConstants.cs
@@ -1,17 +1,6 @@
 ﻿namespace N3O.Umbraco.Scheduler;
 
 public static class SchedulerConstants {
-    public static class Config {
-        public const string DefaultWorkerCount = "N3O:Scheduler:DefaultWorkerCount";
-        public const string LongJobsWorkerCount = "N3O:Scheduler:LongJobsWorkerCount";
-        public const string JobTimeoutMinutes = "N3O:Scheduler:JobTimeoutMinutes";
-    }
-
-    public static class Defaults {
-        public const int WorkerCount = 1;
-        public const int JobTimeoutMinutes = 30;
-    }
-
     public static class Parameters {
         public const string Culture = "culture";
     }

--- a/src/Scheduler/N3O.Umbraco.Scheduler/SchedulerSettings.cs
+++ b/src/Scheduler/N3O.Umbraco.Scheduler/SchedulerSettings.cs
@@ -1,0 +1,9 @@
+namespace N3O.Umbraco.Scheduler;
+
+public class SchedulerSettings {
+    public const string SectionName = "N3O:Scheduler";
+
+    public int DefaultWorkerCount { get; set; } = 1;
+    public int LongJobsWorkerCount { get; set; } = 1;
+    public int JobTimeoutMinutes { get; set; } = 30;
+}

--- a/src/Scheduler/N3O.Umbraco.Scheduler/Services/JobTrigger.cs
+++ b/src/Scheduler/N3O.Umbraco.Scheduler/Services/JobTrigger.cs
@@ -1,4 +1,5 @@
 using Flurl;
+using Microsoft.Extensions.Configuration;
 using N3O.Umbraco.Json;
 using N3O.Umbraco.Scheduler.Models;
 using System;
@@ -14,13 +15,16 @@ public class JobTrigger {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IJsonProvider _jsonProvider;
     private readonly IJobUrlProvider _jobUrlProvider;
+    private readonly IConfiguration _config;
 
     public JobTrigger(IHttpClientFactory httpClientFactory,
                       IJsonProvider jsonProvider,
-                      IJobUrlProvider jobUrlProvider) {
+                      IJobUrlProvider jobUrlProvider,
+                      IConfiguration config) {
         _httpClientFactory = httpClientFactory;
         _jsonProvider = jsonProvider;
         _jobUrlProvider = jobUrlProvider;
+        _config = config;
     }
 
     [DisplayName("{0}")]
@@ -28,8 +32,11 @@ public class JobTrigger {
                                    string triggerKey,
                                    string modelJson,
                                    IReadOnlyDictionary<string, string> parameterData) {
+        var timeoutMinutes = _config.GetValue<int?>(SchedulerConstants.Config.JobTimeoutMinutes) ??
+                             SchedulerConstants.Defaults.JobTimeoutMinutes;
+
         var httpClient = _httpClientFactory.CreateClient();
-        httpClient.Timeout = TimeSpan.FromMinutes(30);
+        httpClient.Timeout = TimeSpan.FromMinutes(timeoutMinutes);
         var req = GetProxyReq(triggerKey, modelJson, parameterData);
         var url = GetUrl();
         var reqStr = _jsonProvider.SerializeObject(req);

--- a/src/Scheduler/N3O.Umbraco.Scheduler/Services/JobTrigger.cs
+++ b/src/Scheduler/N3O.Umbraco.Scheduler/Services/JobTrigger.cs
@@ -1,5 +1,4 @@
 using Flurl;
-using Microsoft.Extensions.Configuration;
 using N3O.Umbraco.Json;
 using N3O.Umbraco.Scheduler.Models;
 using System;
@@ -15,16 +14,16 @@ public class JobTrigger {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IJsonProvider _jsonProvider;
     private readonly IJobUrlProvider _jobUrlProvider;
-    private readonly IConfiguration _config;
+    private readonly SchedulerSettings _settings;
 
     public JobTrigger(IHttpClientFactory httpClientFactory,
                       IJsonProvider jsonProvider,
                       IJobUrlProvider jobUrlProvider,
-                      IConfiguration config) {
+                      SchedulerSettings settings) {
         _httpClientFactory = httpClientFactory;
         _jsonProvider = jsonProvider;
         _jobUrlProvider = jobUrlProvider;
-        _config = config;
+        _settings = settings;
     }
 
     [DisplayName("{0}")]
@@ -32,11 +31,8 @@ public class JobTrigger {
                                    string triggerKey,
                                    string modelJson,
                                    IReadOnlyDictionary<string, string> parameterData) {
-        var timeoutMinutes = _config.GetValue<int?>(SchedulerConstants.Config.JobTimeoutMinutes) ??
-                             SchedulerConstants.Defaults.JobTimeoutMinutes;
-
         var httpClient = _httpClientFactory.CreateClient();
-        httpClient.Timeout = TimeSpan.FromMinutes(timeoutMinutes);
+        httpClient.Timeout = TimeSpan.FromMinutes(_settings.JobTimeoutMinutes);
         var req = GetProxyReq(triggerKey, modelJson, parameterData);
         var url = GetUrl();
         var reqStr = _jsonProvider.SerializeObject(req);


### PR DESCRIPTION
## Linked work issue

re n3oltd/work#3154

## Summary

`N3O.Umbraco.Scheduler` runs each Hangfire job via a synchronous HTTP self-call (`JobTrigger` → `/JobProxy/executeProxied`, 30-min timeout) with `WorkerCount = 1` hardcoded on the `default` queue — so a single hung self-call head-of-line-blocks the whole queue until it times out (the `headless-mh` stall seen in n3oltd/work#2794, recoverable only by a pod restart).

This binds a new `SchedulerSettings` (config section `N3O:Scheduler`) and drives both the Hangfire `WorkerCount` (per queue) and the `JobTrigger` self-call timeout from it, injecting the settings object directly the way the other packages do their settings. Defaults preserve current behaviour (`DefaultWorkerCount`/`LongJobsWorkerCount` = 1, `JobTimeoutMinutes` = 30), so nothing changes unless an org overrides them — e.g. `headless-mh` can set `N3O:Scheduler:DefaultWorkerCount = 2` so one hung job no longer blocks everything.

Umbraco serialises content writes on a global write-lock, so raising workers buys **resilience** (no single-job head-of-line block), not raw throughput — 2 is the target, not a large number.

## Test plan

- [x] `dotnet build` of `N3O.Umbraco.Scheduler` — succeeds, 0 errors
- [ ] With no config set, `WorkerCount` stays 1 and the self-call timeout stays 30 min (defaults preserved)
- [ ] Setting `N3O:Scheduler:DefaultWorkerCount=2` starts the `default` Hangfire server with 2 workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)