### PR TITLE
Blocks.Preview: fix iframe measurement and error banners (follow-up to #906)

### DIFF
--- a/src/Blocks/N3O.Umbraco.Blocks.Perplex/Content/Editor/PropertyBuilder.ContentBlocks.cs
+++ b/src/Blocks/N3O.Umbraco.Blocks.Perplex/Content/Editor/PropertyBuilder.ContentBlocks.cs
@@ -13,13 +13,13 @@ public class ContentBlocksPropertyBuilder : PropertyBuilder {
         _jsonSerializer = jsonSerializer;
     }
 
+    // Perplex reads the stored value with Umbraco's IJsonSerializer, so it is written with the same one.
     public void Set(ContentBlocksValue modelValue) {
         Value = _jsonSerializer.Serialize(modelValue);
     }
 
-    // Perplex reads the stored value with Umbraco's IJsonSerializer, so content blocks JSON that is already
-    // serialised is written through verbatim rather than round-tripped through ContentBlocksValue, which would
-    // rewrite it in the v4 shape and drop anything the model does not represent.
+    // ContentBlocksValue does not represent every stored shape, so already-serialised JSON is written through
+    // as-is rather than round-tripped through it.
     public void SetJson(string json) {
         Value = json;
     }

--- a/src/Blocks/N3O.Umbraco.Blocks.Perplex/PerplexBlocksComposer.cs
+++ b/src/Blocks/N3O.Umbraco.Blocks.Perplex/PerplexBlocksComposer.cs
@@ -26,8 +26,7 @@ namespace N3O.Umbraco.Blocks.Perplex;
 [ComposeAfter(typeof(BlocksComposer))]
 public class PerplexBlocksComposer : Composer {
     public override void Compose(IUmbracoBuilder builder) {
-        // Replace Perplex's ContentBlocks editor with N3OContentBlocksPropertyEditor (same alias) so the fixed
-        // value editor is used — see N3OContentBlocksValueEditor.
+        // N3OContentBlocksPropertyEditor claims the same alias, so only one of the two can be registered.
         builder.WithCollectionBuilder<DataEditorCollectionBuilder>().Exclude<PerplexContentBlocksPropertyEditor>();
 
         BlocksComponent.LoadDefinitions(builder, WebHostEnvironment);

--- a/src/Blocks/N3O.Umbraco.Blocks.Perplex/PropertyEditor/N3OContentBlocksPropertyEditor.cs
+++ b/src/Blocks/N3O.Umbraco.Blocks.Perplex/PropertyEditor/N3OContentBlocksPropertyEditor.cs
@@ -6,8 +6,8 @@ using Umbraco.Cms.Core.Serialization;
 
 namespace N3O.Umbraco.Blocks.Perplex;
 
-// Registers under the same alias as Perplex's own editor (which PerplexBlocksComposer excludes) so the framework
-// resolves N3OContentBlocksValueEditor instead of the defective Perplex one. See N3OContentBlocksValueEditor.
+// Claims Perplex's editor alias, which the composer frees by excluding Perplex's own editor, so
+// N3OContentBlocksValueEditor is the value editor in play.
 [DataEditor("Perplex.ContentBlocks", ValueEditorIsReusable = false, ValueType = ValueTypes.Json)]
 public class N3OContentBlocksPropertyEditor : PerplexContentBlocksPropertyEditor {
     public N3OContentBlocksPropertyEditor(IDataValueEditorFactory dataValueEditorFactory,

--- a/src/Blocks/N3O.Umbraco.Blocks.Perplex/PropertyEditor/N3OContentBlocksValueEditor.cs
+++ b/src/Blocks/N3O.Umbraco.Blocks.Perplex/PropertyEditor/N3OContentBlocksValueEditor.cs
@@ -12,16 +12,12 @@ using Umbraco.Cms.Core.Strings;
 
 namespace N3O.Umbraco.Blocks.Perplex;
 
-// Workaround for a Perplex.ContentBlocks v4 defect: ContentBlocksValueEditor.FromEditor builds the inner
-// ContentPropertyData without ContentKey/PropertyTypeKey, so editors that store a file against the content key
-// (Image Cropper and File Upload) receive Guid.Empty and throw "Invalid content key" on save. This repeats
-// Perplex's FromEditor but threads the owning content key down to each inner property, as Umbraco's own block
-// editor does (BlockValuePropertyValueEditorBase.MapBlockItemDataFromEditor) and as the upstream fix does.
+// Perplex's ContentBlocksValueEditor.FromEditor builds each inner ContentPropertyData without a ContentKey or
+// PropertyTypeKey, so property editors that store a file against them throw "Invalid content key" on save.
+// This repeats that method with both keys threaded down.
 //
-// TODO Remove this folder, the Exclude<> in PerplexBlocksComposer and the exact Perplex.ContentBlocks version
-// pin once the fix ships in a release we can upgrade to:
-//   Issue: https://github.com/PerplexDigital/Perplex.ContentBlocks/issues/102
-//   PR:    https://github.com/PerplexDigital/Perplex.ContentBlocks/pull/103
+// TODO Remove this folder, the Exclude<> in PerplexBlocksComposer and the Perplex.ContentBlocks version
+// pin once https://github.com/PerplexDigital/Perplex.ContentBlocks/issues/102 ships
 public class N3OContentBlocksValueEditor : ContentBlocksValueEditor {
     private readonly IJsonSerializer _jsonSerializer;
     private readonly ContentBlocksValueDeserializer _deserializer;

--- a/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview-app.css
+++ b/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview-app.css
@@ -37,19 +37,12 @@
     white-space: normal;
 }
 
-.preview-alert-warning {
-    background-color: #f0ac00;
-    border-color: transparent;
-    color: #fff;
-}
-
 .preview-alert-info {
     background-color: #3544b1;
     border-color: transparent;
     color: #fff;
 }
 
-.preview-alert-danger,
 .preview-alert-error {
     background-color: #d42054;
     border-color: transparent;

--- a/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview-app.tsx
+++ b/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview-app.tsx
@@ -6,22 +6,19 @@ interface BlockPreviewAppProps {
     state: PreviewState;
 }
 
-// The preview is drawn slightly smaller than life so more of the block fits in the editor. transform does not
-// affect layout, so the surface is given the scaled height and the frame is widened to compensate; otherwise
-// every block reserves its full unscaled height and leaves a gap beneath.
+// transform does not affect layout, so the surface carries the scaled height and the frame is widened to
+// compensate.
 const previewScale = 0.9;
 
-// The markup is a whole rendered page, so it goes in an iframe rather than into the backoffice document:
-// scripts a block needs in order to render run, and the site's own stylesheet applies as it does on the live
-// page. srcDoc keeps the frame same-origin, so its content height can be measured to size the frame.
+// The markup is a whole rendered page: in a frame its scripts run and the site stylesheet applies as it does
+// live. srcDoc keeps the frame same-origin, so its content height is measurable.
 function PreviewFrame({ markup }: { markup: string }) {
     const frameRef = useRef<HTMLIFrameElement>(null);
     const observerRef = useRef<ResizeObserver | null>(null);
     const [height, setHeight] = useState(0);
 
-    // srcDoc navigates the frame, and the navigation is queued rather than synchronous, so an effect runs
-    // while contentDocument is still the outgoing document - or, on the first render, the initial about:blank
-    // one. load is the point at which contentDocument is the document being measured.
+    // srcDoc navigates the frame and the navigation is queued, so during an effect contentDocument is still
+    // the outgoing document, or initially about:blank. load is when it is the document being measured.
     const observeFrame = useCallback(() => {
         observerRef.current?.disconnect();
 

--- a/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview-app.tsx
+++ b/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview-app.tsx
@@ -16,31 +16,37 @@ const previewScale = 0.9;
 // page. srcDoc keeps the frame same-origin, so its content height can be measured to size the frame.
 function PreviewFrame({ markup }: { markup: string }) {
     const frameRef = useRef<HTMLIFrameElement>(null);
+    const observerRef = useRef<ResizeObserver | null>(null);
     const [height, setHeight] = useState(0);
 
-    const measure = useCallback(() => {
-        const body = frameRef.current?.contentDocument?.body;
+    // srcDoc navigates the frame, and the navigation is queued rather than synchronous, so an effect runs
+    // while contentDocument is still the outgoing document - or, on the first render, the initial about:blank
+    // one. load is the point at which contentDocument is the document being measured.
+    const observeFrame = useCallback(() => {
+        observerRef.current?.disconnect();
 
-        if (body) {
-            setHeight(body.scrollHeight);
-        }
-    }, []);
-
-    useEffect(() => {
         const body = frameRef.current?.contentDocument?.body;
 
         if (!body) {
             return;
         }
 
-        const observer = new ResizeObserver(measure);
-        observer.observe(body);
+        // Sizing the frame resizes the content viewport, so any vh or percentage height feeds back into
+        // scrollHeight. The threshold settles that instead of letting it oscillate.
+        const observer = new ResizeObserver(() => {
+            setHeight((current) => (Math.abs(body.scrollHeight - current) > 1 ? body.scrollHeight : current));
+        });
 
-        return () => observer.disconnect();
-    }, [markup, measure]);
+        observer.observe(body);
+        observerRef.current = observer;
+
+        setHeight(body.scrollHeight);
+    }, []);
+
+    useEffect(() => () => observerRef.current?.disconnect(), []);
 
     return (
-        <div className="block-preview-surface" style={{ height: `${Math.round(height * previewScale)}px` }}>
+        <div className="block-preview-surface" style={{ height: `${Math.ceil(height * previewScale)}px` }}>
             <iframe
                 ref={frameRef}
                 className="block-preview-frame"
@@ -51,7 +57,7 @@ function PreviewFrame({ markup }: { markup: string }) {
                     width: `${100 / previewScale}%`,
                     transform: `scale(${previewScale})`,
                 }}
-                onLoad={measure}
+                onLoad={observeFrame}
             />
         </div>
     );

--- a/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview.ts
+++ b/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview.ts
@@ -17,6 +17,7 @@ import type { PreviewState } from './types';
 const elementName = 'n3o-block-preview';
 const previewEndpoint = '/umbraco/backoffice/api/blockPreviewBackoffice/previewGridBlock';
 const editDebounceMs = 500;
+const previewFailedMessage = 'Failed getting block preview markup';
 
 interface BlockGridValue {
     layout: { 'Umbraco.BlockGrid': UmbBlockLayoutBaseModel[] };
@@ -222,13 +223,17 @@ export class N3oBlockPreviewElement extends UmbAuthFetchMixin(UmbElementMixin(HT
                 return;
             }
 
-            const message = error instanceof Error ? error.message : String(error);
+            console.error('Block preview failed', error);
 
-            this.#notificationContext?.peek('danger', {
-                data: { headline: 'Block preview', message: 'Failed getting block preview markup' },
-            });
+            // A block that keeps failing reloads on every edit, so only the transition into failure is
+            // announced; backoffice toasts stack and would otherwise pile up as the editor types.
+            if (this.#state.status !== 'error') {
+                this.#notificationContext?.peek('danger', {
+                    data: { headline: 'Block preview', message: previewFailedMessage },
+                });
+            }
 
-            this.#setState({ status: 'error', message });
+            this.#setState({ status: 'error', message: previewFailedMessage });
         } finally {
             if (this.#inFlight === abort) {
                 this.#inFlight = undefined;

--- a/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview.ts
+++ b/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview.ts
@@ -79,7 +79,14 @@ export class N3oBlockPreviewElement extends UmbAuthFetchMixin(UmbElementMixin(HT
                 return;
             }
 
+            // Re-subscribing replays the current value, and consumeContext can run more than once, so each
+            // observer reloads only when the value it feeds into the request has actually moved. The abort is
+            // client-side, so a redundant request still costs a server-side Razor render.
             this.observe(context.unique, (unique) => {
+                if (unique === this.#nodeKey) {
+                    return;
+                }
+
                 this.#nodeKey = unique;
                 this.#scheduleReload(0);
             }, '_observeUnique');
@@ -87,7 +94,13 @@ export class N3oBlockPreviewElement extends UmbAuthFetchMixin(UmbElementMixin(HT
             this.observe(
                 context.splitView.activeVariantsInfo,
                 (infos) => {
-                    this.#culture = infos[0]?.culture ?? '';
+                    const culture = infos[0]?.culture ?? '';
+
+                    if (culture === this.#culture) {
+                        return;
+                    }
+
+                    this.#culture = culture;
                     this.#scheduleReload(0);
                 },
                 '_observeCulture'
@@ -100,17 +113,29 @@ export class N3oBlockPreviewElement extends UmbAuthFetchMixin(UmbElementMixin(HT
             }
 
             this.observe(context.contentKey, (key) => {
+                if (key === this.#contentKey) {
+                    return;
+                }
+
                 this.#contentKey = key;
                 this.#scheduleReload(0);
             }, '_observeContentKey');
 
             this.observe(context.contentElementTypeKey, (key) => {
+                if (key === this.#contentElementTypeKey) {
+                    return;
+                }
+
                 this.#contentElementTypeKey = key;
                 this.#scheduleReload(0);
             }, '_observeContentElementTypeKey');
         });
 
         this.consumeContext(UMB_BLOCK_MANAGER_CONTEXT, (context) => {
+            if (!context || context === this.#blockManager) {
+                return;
+            }
+
             this.#blockManager = context;
             this.#scheduleReload(0);
         });

--- a/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview.ts
+++ b/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview.ts
@@ -30,6 +30,7 @@ interface BlockGridValue {
 export class N3oBlockPreviewElement extends UmbAuthFetchMixin(UmbElementMixin(HTMLElement)) implements UmbBlockEditorCustomViewElement {
     #content?: UmbBlockEditorCustomViewElement['content'];
     #settings?: UmbBlockEditorCustomViewElement['settings'];
+    #layout?: UmbBlockEditorCustomViewElement['layout'];
 
     get content(): UmbBlockEditorCustomViewElement['content'] {
         return this.#content;
@@ -46,6 +47,17 @@ export class N3oBlockPreviewElement extends UmbAuthFetchMixin(UmbElementMixin(HT
 
     set settings(value: UmbBlockEditorCustomViewElement['settings']) {
         this.#settings = value;
+        this.#onDataChanged();
+    }
+
+    // Resizing a block changes its layout entry rather than its content, and the preview is rendered from the
+    // whole grid value, so column and row spans have to re-render it too.
+    get layout(): UmbBlockEditorCustomViewElement['layout'] {
+        return this.#layout;
+    }
+
+    set layout(value: UmbBlockEditorCustomViewElement['layout']) {
+        this.#layout = value;
         this.#onDataChanged();
     }
 

--- a/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview.ts
+++ b/src/Blocks/N3O.Umbraco.Blocks.StaticAssets/frontend/blocks-preview/src/block-preview.ts
@@ -50,8 +50,8 @@ export class N3oBlockPreviewElement extends UmbAuthFetchMixin(UmbElementMixin(HT
         this.#onDataChanged();
     }
 
-    // Resizing a block changes its layout entry rather than its content, and the preview is rendered from the
-    // whole grid value, so column and row spans have to re-render it too.
+    // The preview is rendered from the whole grid value, so a block's column and row spans change it as much
+    // as its content does.
     get layout(): UmbBlockEditorCustomViewElement['layout'] {
         return this.#layout;
     }
@@ -91,9 +91,8 @@ export class N3oBlockPreviewElement extends UmbAuthFetchMixin(UmbElementMixin(HT
                 return;
             }
 
-            // Re-subscribing replays the current value, and consumeContext can run more than once, so each
-            // observer reloads only when the value it feeds into the request has actually moved. The abort is
-            // client-side, so a redundant request still costs a server-side Razor render.
+            // Re-subscribing replays the current value, so each observer reloads only when its own request
+            // parameter changes. Aborting is client-side; a redundant request still costs a server render.
             this.observe(context.unique, (unique) => {
                 if (unique === this.#nodeKey) {
                     return;
@@ -209,8 +208,7 @@ export class N3oBlockPreviewElement extends UmbAuthFetchMixin(UmbElementMixin(HT
         };
     }
 
-    // documentTypeKey is the wire name of the query parameter; the value the endpoint wants is the block's
-    // element type key.
+    // The endpoint's documentTypeKey parameter receives the block's element type key.
     #buildPreviewUrl(contentKey: string, contentElementTypeKey: string): string {
         const query = new URLSearchParams({
             nodeKey: this.#nodeKey ?? '',
@@ -262,8 +260,7 @@ export class N3oBlockPreviewElement extends UmbAuthFetchMixin(UmbElementMixin(HT
 
             console.error('Block preview failed', error);
 
-            // A block that keeps failing reloads on every edit, so only the transition into failure is
-            // announced; backoffice toasts stack and would otherwise pile up as the editor types.
+            // Backoffice toasts stack, so only the transition into failure is announced.
             if (this.#state.status !== 'error') {
                 this.#notificationContext?.peek('danger', {
                     data: { headline: 'Block preview', message: previewFailedMessage },

--- a/src/Blocks/N3O.Umbraco.Blocks/Exceptions/BlockPreviewException.cs
+++ b/src/Blocks/N3O.Umbraco.Blocks/Exceptions/BlockPreviewException.cs
@@ -1,21 +1,32 @@
-﻿using System;
+using System;
+using System.Net;
 
 namespace N3O.Umbraco.Blocks.Exceptions;
 
+// Markup is returned with a 200 and rendered in the preview frame, which is a document of its own that the
+// backoffice plugin's stylesheet does not reach, so each banner is a self-contained document carrying its own
+// styling.
 public abstract class BlockPreviewException : Exception {
     protected BlockPreviewException(string message) : base(message) { }
-    
+
     public abstract string Markup { get; }
+
+    protected string GetBannerMarkup(string backgroundColor) {
+        return "<!DOCTYPE html><html><head><meta charset=\"utf-8\"></head>" +
+               "<body style=\"margin:0;font-family:sans-serif;font-size:14px\">" +
+               $"<div style=\"background-color:{backgroundColor};color:#fff;padding:8px 14px\">" +
+               $"{WebUtility.HtmlEncode(Message)}</div></body></html>";
+    }
 }
 
 public class BlockPreviewErrorException : BlockPreviewException {
     public BlockPreviewErrorException(string message) : base(message) { }
 
-    public override string Markup => $"<div class=\"preview-alert preview-alert-error\">{Message}</div>";
+    public override string Markup => GetBannerMarkup("#d42054");
 }
 
 public class BlockPreviewWarningException : BlockPreviewException {
     public BlockPreviewWarningException(string message) : base(message) { }
 
-    public override string Markup => $"<div class=\"preview-alert preview-alert-warning\">{Message}</div>";
+    public override string Markup => GetBannerMarkup("#f0ac00");
 }

--- a/src/Blocks/N3O.Umbraco.Blocks/Exceptions/BlockPreviewException.cs
+++ b/src/Blocks/N3O.Umbraco.Blocks/Exceptions/BlockPreviewException.cs
@@ -3,9 +3,8 @@ using System.Net;
 
 namespace N3O.Umbraco.Blocks.Exceptions;
 
-// Markup is returned with a 200 and rendered in the preview frame, which is a document of its own that the
-// backoffice plugin's stylesheet does not reach, so each banner is a self-contained document carrying its own
-// styling.
+// Banners render in the preview frame, a document the backoffice stylesheet does not reach, so each carries
+// its own styling.
 public abstract class BlockPreviewException : Exception {
     protected BlockPreviewException(string message) : base(message) { }
 

--- a/src/Data/N3O.Umbraco.Data.PerplexBlocks/PropertyConverter.ContentBlocks.cs
+++ b/src/Data/N3O.Umbraco.Data.PerplexBlocks/PropertyConverter.ContentBlocks.cs
@@ -45,9 +45,8 @@ public class ContentBlocksPropertyConverter : PropertyConverter<string> {
         }
     }
 
-    // The cell is written to the property verbatim, so it is checked for well-formedness and for the one member
-    // every content blocks value has. Shape beyond that is deliberately not asserted: both the v3 and the v4
-    // layouts are valid here, and Perplex owns which of them it can read.
+    // The cell is stored verbatim, so it is checked only for well-formedness and the member every content
+    // blocks value carries. More than one layout is valid, and Perplex owns which of them it reads.
     private static bool IsContentBlocksJson(string json) {
         try {
             return JsonNode.Parse(json) is JsonObject jsonObject && jsonObject.ContainsKey("blocks");

--- a/src/N3O.Umbraco.Extensions/Content/ContentHelper.cs
+++ b/src/N3O.Umbraco.Extensions/Content/ContentHelper.cs
@@ -184,9 +184,8 @@ public class ContentHelper : IContentHelper {
         return contentProperties;
     }
 
-    // Perplex ContentBlocks holds each block's content as a v4 Block Editor element (contentTypeKey plus
-    // values) once its own v3-to-v4 migration has run, and as the v3 NestedContent shape until then. Either
-    // shape can be stored, so the payload is dispatched to the element parser matching it.
+    // Block content is stored either as a Block Editor element carrying a contentTypeKey, or as a
+    // NestedContent array.
     private IReadOnlyList<ContentProperties> GetContentPropertiesForPerplexBlock(JToken block) {
         var content = block?["content"];
 


### PR DESCRIPTION
Follow-up to #906. An adversarial review of the block-preview commits completed a few minutes after that PR merged and found two confirmed defects in the iframe change, plus three smaller ones. All five are fixed here, one commit per issue.

## Blocking

**The ResizeObserver never observed the document being displayed.** `srcDoc` navigates the frame and the navigation is queued, not synchronous. On insertion the browser synchronously creates the initial `about:blank` document, so `contentDocument.body` is already non-null — but it is the wrong body, and it is discarded when the srcdoc document commits; a `ResizeObserver` on a detached element reports nothing. On subsequent loads there is no race at all: the effect re-runs in the same commit's passive flush, before the new document exists, so it observes the *outgoing* one.

Height was therefore measured exactly once per load, at the `load` event. Fine for images and synchronous scripts (the frame's `load` waits for subresources), wrong for JS-built DOM, accordions and carousels that lay out after load, web-font swap reflow and lazy images — which are the blocks the iframe exists to render. Taller content is clipped by the surface, shorter leaves a gap. It also measured while the frame was still `0px` high, so `vh` and percentage heights in the site stylesheet resolved against a zero-height viewport.

Now attached from `load`, re-attached per load, with a 1px threshold — sizing the frame resizes the content viewport, so a `vh` rule feeds its own height back in and would otherwise oscillate and trip *"ResizeObserver loop completed with undelivered notifications"*.

**Server error banners rendered unstyled.** `BlockPreviewException` returned `<div class="preview-alert preview-alert-error">` and the controller returns it with a **200** — indistinguishable from real markup, deliberately, so the banner renders where the preview would. That relied on the div landing in the plugin's shadow root, where `block-preview-app.css` styled it. Inside an iframe our stylesheet does not reach it, so banners were black text on white. Not an edge case: `BlockPreviewWarningException("No published content found")` fires whenever `nodeKey` does not resolve, e.g. on a document that has never been saved.

Each banner is now a self-contained document with inline styling in the same two colours, and the message is HTML-encoded — it was interpolated raw, which was survivable inside the backoffice shadow root and is not now that it is a document. The client cannot fix this, since it has no way to tell a 200 banner from a 200 preview.

## Also fixed

- **Notification storm.** Removing the retry gate in #906 meant a persistently failing load fired a `peek('danger')` per debounce window while the editor typed, and backoffice toasts stack. Only the transition into failure is announced now.
- **Inverted messages.** The inline panel rendered `error.message` (`TypeError: Failed to fetch`) while the toast carried the readable text. Both now carry the readable text; detail goes to the console.
- **Redundant requests.** `consumeContext` callbacks can run more than once and each `this.observe(...)` re-subscription replays the current value, so identical values scheduled further loads. `AbortController` cancels the client's interest, not the server's Razor render. Each observer now compares before assigning. The block-manager callback also gains the null guard its siblings had.
- **Block resize** (`columnSpan`/`rowSpan`) worked only by accident — Umbraco re-assigns every prop with no dirty check, so the `content` setter fired incidentally. `layout` is a declared member of `UmbBlockEditorCustomViewProperties` and is now implemented properly.

## Cleared, not changed

The same review confirmed two things I had flagged as risks: `srcDoc` is same-origin (no `sandbox`, no CSP/`frame-src` anywhere in the repo), so `contentDocument` is readable and the preview is not invisible; and the iframe does **not** worsen click-to-edit, because v17 has no click handler on the block body — the edit affordance is the action-bar pencil, rendered outside the extension slot.

## Verification

`tsc --noEmit` and `vite build` green for `@n3oltd/blocks-preview` on every commit. Per AGENTS.md this class of change only shows in a browser, so before merge please open a block grid in a real backoffice and confirm: a block whose content grows after load resizes to fit; an unsaved document shows a styled amber "No published content found" banner; and resizing a block re-renders its preview.

re n3oltd/work#729
