### PR TITLE
Blocks.Perplex: fix block head duplication, startup failure and the version pin (follow-up to #906)

### DIFF
--- a/src/Blocks/N3O.Umbraco.Blocks.Perplex/Models/PerplexBlockDefinition.cs
+++ b/src/Blocks/N3O.Umbraco.Blocks.Perplex/Models/PerplexBlockDefinition.cs
@@ -43,7 +43,7 @@ public class PerplexBlockDefinition : Value, IContentBlockDefinition {
     public string Folder { get; }
     public string PreviewImage { get; }
     public Guid ElementTypeKey => Id;
-    public string BlockNameTemplate => Name;
+    public string BlockNameTemplate => null;
     public IReadOnlyList<PerplexBlockCategory> BlockCategories { get; }
     public IEnumerable<Guid> CategoryIds => _categoryIds;
     public IReadOnlyList<LayoutDefinition> Layouts { get; }

--- a/src/Blocks/N3O.Umbraco.Blocks.Perplex/N3O.Umbraco.Blocks.Perplex.csproj
+++ b/src/Blocks/N3O.Umbraco.Blocks.Perplex/N3O.Umbraco.Blocks.Perplex.csproj
@@ -41,6 +41,6 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Perplex.ContentBlocks" Version="[4.0.2]" />
+        <PackageReference Include="Perplex.ContentBlocks" Version="4.0.2" />
     </ItemGroup>
 </Project>

--- a/src/Blocks/N3O.Umbraco.Blocks.Perplex/PerplexBlocksComposer.cs
+++ b/src/Blocks/N3O.Umbraco.Blocks.Perplex/PerplexBlocksComposer.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using N3O.Umbraco.Blocks.Perplex.Extensions;
 using N3O.Umbraco.Composing;
 using N3O.Umbraco.Content;
@@ -57,17 +58,20 @@ public class BlocksComponent : IAsyncComponent {
     public static IReadOnlyList<PerplexBlockDefinition> BlockDefinitions { get; private set; }
 
     private readonly IRuntimeState _runtimeState;
+    private readonly ILogger<BlocksComponent> _logger;
     private readonly Lazy<IPerplexBlockTypesService> _blockTypesService;
     private readonly Lazy<ILookups> _lookups;
     private readonly Lazy<IContentBlockDefinitionRepository> _blockDefinitionsRepository;
     private readonly Lazy<IContentBlockCategoryRepository> _blockCategoriesRepository;
 
     public BlocksComponent(IRuntimeState runtimeState,
+                           ILogger<BlocksComponent> logger,
                            Lazy<IPerplexBlockTypesService> blockTypesService,
                            Lazy<ILookups> lookups,
                            Lazy<IContentBlockDefinitionRepository> blockDefinitionsRepository,
                            Lazy<IContentBlockCategoryRepository> blockCategoriesRepository) {
         _runtimeState = runtimeState;
+        _logger = logger;
         _blockTypesService = blockTypesService;
         _lookups = lookups;
         _blockDefinitionsRepository = blockDefinitionsRepository;
@@ -83,9 +87,17 @@ public class BlocksComponent : IAsyncComponent {
 
             blockCategories.Do(x => _blockCategoriesRepository.Value.Add(x));
 
+            // Component initialisation runs outside any handler in the Umbraco runtime, so an exception here
+            // fails host startup and the site serves nothing. One unusable block definition is contained to
+            // itself instead.
             foreach (var x in BlockDefinitions) {
-                await _blockTypesService.Value.CreateTypesAsync(x);
-                _blockDefinitionsRepository.Value.Add(x);
+                try {
+                    await _blockTypesService.Value.CreateTypesAsync(x);
+
+                    _blockDefinitionsRepository.Value.Add(x);
+                } catch (Exception ex) {
+                    _logger.LogError(ex, "Failed to create block types for {Alias}", x.Alias);
+                }
             }
         }
     }


### PR DESCRIPTION
Follow-up to #906. A retrospective review of the five Perplex commits that shipped in that PR **without an agent review** found two FAILs and one availability regression. All three are fixed here, one commit per issue.

Scope is deliberately Perplex/startup only; the block-preview follow-ups are in #909.

## Blocking

**A failed block definition takes the whole site down.** `CreateTypesAsync` now throws when a content type cannot be created — correct for a service — but `BlocksComponent.InitializeAsync` called it in a bare loop. Umbraco's `CoreRuntime` awaits component initialisation **outside any try**, so the exception leaves `IHostedService.StartAsync` and the host does not start. Not the boot error page — no HTTP surface at all. One unusable definition (an alias colliding with a stale content type, an alias the shortstring helper rejects) would take a public site down until someone deployed a fix; previously that block was skipped and the rest of the site served.

Each definition is now attempted independently, failures logged and stepped over. The service keeps its throws — the codebase's split is that services raise and callers decide. All three throw points are idempotent on the next boot (containers and composition are fetched before creation, the element type is guarded by an existence check), so a definition that fails once retries cleanly rather than being left half-created.

**Every collapsed block head renders its name twice.** `BlockNameTemplate => Name` was set on the premise that a null template left the head blank. It doesn't: `pcb-block-head` renders `blockDefinitionName` unconditionally into `.block-head__description`, and applies `--no-title` when no block name value is set, which styles that element at default size and weight 700 — the description element *is* the title. Setting the template renders the name bold via `umb-ufm-render` **and** again in small print beneath it.

It's also the wrong member. `BlockNameTemplate` is a per-instance UFM template for naming a block from its own content (`{umbValue: title}` in the release notes); a definition name is constant per type. And the value is passed to `umb-ufm-render` as markdown, so a name containing markdown punctuation would render as formatting. Reverted to `null`.

**The exact version pin doesn't pin what it was meant to.** `N3OContentBlocksValueEditor` copies the body of `ContentBlocksValueEditor.FromEditor`, and `Version="[4.0.2]"` was placed on `Perplex.ContentBlocks` to stop that base class floating. That package ships **no assembly** — I downloaded the nupkg; it contains only a nuspec, an icon, `[Content_Types].xml` and the signature — and declares `Perplex.ContentBlocks.Core version="4.0.2"`, which NuGet reads as a **floor**. `ContentBlocksValueEditor` lives in Core. So anything in a consuming graph requiring a later Core resolves it, restore succeeds with no warning, and the copy silently diverges from its base. Core is now pinned exactly alongside.

## Two things for a human to decide

1. **Downstream lock-in.** `N3O.Umbraco.Blocks.Perplex` is packable, so an exact range propagates into its nuspec and locks every consuming site to exactly 4.0.2 — a site wanting 4.0.3 gets an unresolvable restore. That's lock-in imposed on consumers to protect an internal workaround. It was already true of the existing pin; this PR doubles it. Worth deciding whether the constraint belongs in the shipped package or only in this solution's restore.
2. **The `4.0.2` justification in #906 was wrong**, even though taking 4.0.2 is fine. The release notes were quoted accurately (4.0.1 re-adds missing mandatory preset blocks; 4.0.2 hides `isHidden` categories) but neither applies here: no presets are used anywhere in the repo, and `PerplexBlockCategory` hardcodes `IsHidden = false` while the two built-in categories are *removed* rather than hidden.

## Note on #909

#909 rewords the TODO on the value editor and refers to "the Perplex.ContentBlocks version pin", singular. Whichever of these merges second needs that phrase to name both pins.

## Verification

The workaround's premise still holds: upstream issue #102 and PR #103 are both **OPEN**, and `ContentBlocksValueEditor.FromEditor` on `master` still builds each inner `ContentPropertyData` without a `ContentKey`.

Not verified by a build: `v17` does not restore end to end (pre-existing `DemoSite` NU1201), and there is no PR CI in this repo. The Core pin's restorability is established from the flat-container feed and nuspec closure — 4.0.2 exists, targets `net10.0`, and requires only `Umbraco.Cms.Api.Management >= 17.0.0` against the pinned 17.3.5 — not from a `dotnet restore`. Someone should confirm with a real restore before merge.

re n3oltd/work#729
