### PR TITLE
Refresh NuGet references: latest patch/minor across the repo, drop four redundant references

### DIFF
--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/N3O.Umbraco.Authentication.Auth0.csproj
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/N3O.Umbraco.Authentication.Auth0.csproj
@@ -39,7 +39,6 @@
         <PackageReference Include="Auth0.AuthenticationApi" Version="7.48.0" />
         <PackageReference Include="Auth0.ManagementApi" Version="8.5.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
-        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.21.0" />
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.21.0" />
         <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.21.0" />
     </ItemGroup>

--- a/src/Authentication/N3O.Umbraco.Authentication.Auth0/N3O.Umbraco.Authentication.Auth0.csproj
+++ b/src/Authentication/N3O.Umbraco.Authentication.Auth0/N3O.Umbraco.Authentication.Auth0.csproj
@@ -36,12 +36,12 @@
         <ProjectReference Include="..\N3O.Umbraco.Authentication\N3O.Umbraco.Authentication.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Auth0.AuthenticationApi" Version="7.46.0" />
+        <PackageReference Include="Auth0.AuthenticationApi" Version="7.48.0" />
         <PackageReference Include="Auth0.ManagementApi" Version="8.5.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
-        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
-        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
-        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
+        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.21.0" />
+        <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.21.0" />
+        <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.21.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="README.md">

--- a/src/Blocks/N3O.Umbraco.Blocks/N3O.Umbraco.Blocks.csproj
+++ b/src/Blocks/N3O.Umbraco.Blocks/N3O.Umbraco.Blocks.csproj
@@ -41,7 +41,7 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.10" />
         <PackageReference Include="Razor.Templating.Core" Version="2.1.0" />
     </ItemGroup>
 </Project>

--- a/src/Data/N3O.Umbraco.Data/N3O.Umbraco.Data.csproj
+++ b/src/Data/N3O.Umbraco.Data/N3O.Umbraco.Data.csproj
@@ -50,9 +50,9 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="1.4.0" />
+        <PackageReference Include="AngleSharp" Version="1.5.2" />
         <PackageReference Include="CsvHelper" Version="33.1.0" />
-        <PackageReference Include="EPPlus" Version="8.6.0" />
-        <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
+        <PackageReference Include="EPPlus" Version="8.6.3" />
+        <PackageReference Include="HtmlSanitizer" Version="9.0.967" />
     </ItemGroup>
 </Project>

--- a/src/Data/N3O.Umbraco.Data/N3O.Umbraco.Data.csproj
+++ b/src/Data/N3O.Umbraco.Data/N3O.Umbraco.Data.csproj
@@ -50,7 +50,6 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="1.5.2" />
         <PackageReference Include="CsvHelper" Version="33.1.0" />
         <PackageReference Include="EPPlus" Version="8.6.3" />
         <PackageReference Include="HtmlSanitizer" Version="9.0.967" />

--- a/src/Email/N3O.Umbraco.Email.Amazon/N3O.Umbraco.Email.Amazon.csproj
+++ b/src/Email/N3O.Umbraco.Email.Amazon/N3O.Umbraco.Email.Amazon.csproj
@@ -41,6 +41,6 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="AWSSDK.SimpleEmail" Version="4.0.3" />
+        <PackageReference Include="AWSSDK.SimpleEmail" Version="4.0.100.6" />
     </ItemGroup>
 </Project>

--- a/src/Markup/N3O.Umbraco.Markup.Markdown/N3O.Umbraco.Markup.Markdown.csproj
+++ b/src/Markup/N3O.Umbraco.Markup.Markdown/N3O.Umbraco.Markup.Markdown.csproj
@@ -41,6 +41,6 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Markdig" Version="1.2.0" />
+        <PackageReference Include="Markdig" Version="1.3.2" />
     </ItemGroup>
 </Project>

--- a/src/MessageBus/N3O.Umbraco.MessageBus.Azure/N3O.Umbraco.MessageBus.Azure.csproj
+++ b/src/MessageBus/N3O.Umbraco.MessageBus.Azure/N3O.Umbraco.MessageBus.Azure.csproj
@@ -41,6 +41,6 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
     </ItemGroup>
 </Project>

--- a/src/Monitoring/N3O.Umbraco.Monitoring.Sentry/N3O.Umbraco.Monitoring.Sentry.csproj
+++ b/src/Monitoring/N3O.Umbraco.Monitoring.Sentry/N3O.Umbraco.Monitoring.Sentry.csproj
@@ -36,8 +36,8 @@
         <ProjectReference Include="..\N3O.Umbraco.Monitoring\N3O.Umbraco.Monitoring.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Sentry.AspNetCore" Version="6.4.1" />
-        <PackageReference Include="Sentry.Serilog" Version="6.4.1" />
+        <PackageReference Include="Sentry.AspNetCore" Version="6.7.0" />
+        <PackageReference Include="Sentry.Serilog" Version="6.7.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="README.md">

--- a/src/N3O.Umbraco.Clients/N3O.Umbraco.Clients.csproj
+++ b/src/N3O.Umbraco.Clients/N3O.Umbraco.Clients.csproj
@@ -38,8 +38,8 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     </ItemGroup>
     <ItemGroup>

--- a/src/N3O.Umbraco.Cms/N3O.Umbraco.Cms.csproj
+++ b/src/N3O.Umbraco.Cms/N3O.Umbraco.Cms.csproj
@@ -37,10 +37,10 @@
         <ProjectReference Include="..\N3O.Umbraco.ReactRuntime\N3O.Umbraco.ReactRuntime.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Diplo.GodMode" Version="17.0.0" />
+        <PackageReference Include="Diplo.GodMode" Version="17.1.5" />
         <PackageReference Include="Umbraco.Community.Contentment" Version="6.1.4" />
         <PackageReference Include="Umbraco.Cms" Version="17.3.5" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.10" />
     </ItemGroup>
     <ItemGroup>
         <None Update="README.md">

--- a/src/N3O.Umbraco.Extensions/N3O.Umbraco.Extensions.csproj
+++ b/src/N3O.Umbraco.Extensions/N3O.Umbraco.Extensions.csproj
@@ -37,15 +37,15 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="AsyncKeyedLock" Version="8.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
         <PackageReference Include="Flurl" Version="4.0.0" />
         <PackageReference Include="Flurl.Http.Newtonsoft" Version="0.9.1" />
         <!--There is a bug in Humanizer.Core v3.0.10, wait for next release to upgrade the package-->
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
         <PackageReference Include="MimeTypesMap" Version="1.0.9" />
-        <PackageReference Include="NodaTime" Version="3.3.2" />
-        <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.2.1" />
+        <PackageReference Include="NodaTime" Version="3.3.3" />
+        <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.3.0" />
         <PackageReference Include="NSwag.AspNetCore" Version="14.7.1" />
         <PackageReference Include="Umbraco.Community.Contentment" Version="6.1.4" />
         <PackageReference Include="Refit" Version="10.2.0" />

--- a/src/N3O.Umbraco.Extensions/N3O.Umbraco.Extensions.csproj
+++ b/src/N3O.Umbraco.Extensions/N3O.Umbraco.Extensions.csproj
@@ -48,7 +48,6 @@
         <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.3.0" />
         <PackageReference Include="NSwag.AspNetCore" Version="14.7.1" />
         <PackageReference Include="Umbraco.Community.Contentment" Version="6.1.4" />
-        <PackageReference Include="Refit" Version="10.2.0" />
         <PackageReference Include="Refit.Newtonsoft.Json" Version="10.2.0" />
         <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
         <PackageReference Include="Slugify.Core" Version="5.1.1" />

--- a/src/Newsletters/N3O.Umbraco.Newsletters.Mailchimp/N3O.Umbraco.Newsletters.Mailchimp.csproj
+++ b/src/Newsletters/N3O.Umbraco.Newsletters.Mailchimp/N3O.Umbraco.Newsletters.Mailchimp.csproj
@@ -36,7 +36,7 @@
         <ProjectReference Include="..\N3O.Umbraco.Newsletters\N3O.Umbraco.Newsletters.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MailChimp.Net.V3" Version="5.5.0" />
+        <PackageReference Include="MailChimp.Net.V3" Version="5.8.2" />
     </ItemGroup>
     <ItemGroup>
         <None Update="README.md">

--- a/src/Payments/N3O.Umbraco.Payments.GoCardless/N3O.Umbraco.Payments.GoCardless.csproj
+++ b/src/Payments/N3O.Umbraco.Payments.GoCardless/N3O.Umbraco.Payments.GoCardless.csproj
@@ -41,6 +41,6 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="GoCardless" Version="9.5.0" />
+        <PackageReference Include="GoCardless" Version="9.7.0" />
     </ItemGroup>
 </Project>

--- a/src/Plugins/EditorJs/N3O.Umbraco.EditorJs/N3O.Umbraco.EditorJs.csproj
+++ b/src/Plugins/EditorJs/N3O.Umbraco.EditorJs/N3O.Umbraco.EditorJs.csproj
@@ -42,7 +42,7 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="1.4.0" />
-        <PackageReference Include="AngleSharp.Css" Version="0.17.0" />
+        <PackageReference Include="AngleSharp" Version="1.5.2" />
+        <PackageReference Include="AngleSharp.Css" Version="0.18.0" />
     </ItemGroup>
 </Project>

--- a/src/Scheduler/N3O.Umbraco.Scheduler/N3O.Umbraco.Scheduler.csproj
+++ b/src/Scheduler/N3O.Umbraco.Scheduler/N3O.Umbraco.Scheduler.csproj
@@ -37,9 +37,9 @@
         <ProjectReference Include="..\..\N3O.Umbraco.Extensions\N3O.Umbraco.Extensions.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Hangfire" Version="1.8.23" />
-        <PackageReference Include="Hangfire.SqlServer" Version="1.8.23" />
-        <PackageReference Include="OpenIddict.Server" Version="7.2.0" />
+        <PackageReference Include="Hangfire" Version="1.8.24" />
+        <PackageReference Include="Hangfire.SqlServer" Version="1.8.24" />
+        <PackageReference Include="OpenIddict.Server" Version="7.6.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="README.md">

--- a/src/Search/N3O.Umbraco.Search.Google/N3O.Umbraco.Search.Google.csproj
+++ b/src/Search/N3O.Umbraco.Search.Google/N3O.Umbraco.Search.Google.csproj
@@ -36,7 +36,7 @@
         <ProjectReference Include="..\N3O.Umbraco.Search\N3O.Umbraco.Search.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Google.Apis.CustomSearchAPI.v1" Version="1.68.0.3520" />
+        <PackageReference Include="Google.Apis.CustomSearchAPI.v1" Version="1.74.0.3520" />
     </ItemGroup>
     <ItemGroup>
         <None Update="README.md">

--- a/src/Search/N3O.Umbraco.Search.Typesense/N3O.Umbraco.Search.Typesense.csproj
+++ b/src/Search/N3O.Umbraco.Search.Typesense/N3O.Umbraco.Search.Typesense.csproj
@@ -42,6 +42,6 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Typesense" Version="8.3.0" />
+        <PackageReference Include="Typesense" Version="8.5.0" />
     </ItemGroup>
 </Project>

--- a/src/Search/N3O.Umbraco.Search/N3O.Umbraco.Search.csproj
+++ b/src/Search/N3O.Umbraco.Search/N3O.Umbraco.Search.csproj
@@ -38,7 +38,7 @@
         <ProjectReference Include="..\..\Scheduler\N3O.Umbraco.Scheduler\N3O.Umbraco.Scheduler.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="AngleSharp" Version="1.4.0" />
+        <PackageReference Include="AngleSharp" Version="1.5.2" />
     </ItemGroup>
     <ItemGroup>
         <None Update="README.md">

--- a/src/Storage/N3O.Umbraco.Storage.Azure/N3O.Umbraco.Storage.Azure.csproj
+++ b/src/Storage/N3O.Umbraco.Storage.Azure/N3O.Umbraco.Storage.Azure.csproj
@@ -37,7 +37,6 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.5.3" />
-        <PackageReference Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.2.0" />
         <PackageReference Include="Umbraco.StorageProviders.AzureBlob" Version="17.0.0" />
         <PackageReference Include="Umbraco.StorageProviders.AzureBlob.ImageSharp" Version="17.0.0" />
     </ItemGroup>

--- a/src/Telemetry/N3O.Umbraco.Telemetry/N3O.Umbraco.Telemetry.csproj
+++ b/src/Telemetry/N3O.Umbraco.Telemetry/N3O.Umbraco.Telemetry.csproj
@@ -33,11 +33,11 @@
         <DebugType>pdbonly</DebugType>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
-        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\N3O.Umbraco.Extensions\N3O.Umbraco.Extensions.csproj" />

--- a/src/Validation/N3O.Umbraco.Validation/N3O.Umbraco.Validation.csproj
+++ b/src/Validation/N3O.Umbraco.Validation/N3O.Umbraco.Validation.csproj
@@ -39,7 +39,7 @@
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="12.1.1" />
         <PackageReference Include="ISO3166" Version="1.0.4" />
-        <PackageReference Include="libphonenumber-csharp" Version="9.0.29" />
+        <PackageReference Include="libphonenumber-csharp" Version="9.0.35" />
         <PackageReference Include="Profanity.Detector" Version="0.1.8" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
## Summary

Refreshes NuGet references across the repo. Every package is moved to its latest release **within its current major**, and four references are removed that arrive transitively and are never used in code.

Versions in this repo name the release in use and are moved by hand, so this is that manual step. There was no version drift to fix — all 86 packages already had exactly one version repo-wide, and they still do.

**34 packages bumped across 19 projects**, all patch or minor. Examples: `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` 10.0.8 → 10.0.10 (in both `Blocks` and `Cms`, so they stay aligned), `Microsoft.IdentityModel.*` 8.19.1 → 8.21.0, `OpenTelemetry.*` 1.11.x → 1.17.0, `AngleSharp` 1.4.0 → 1.5.2, `Sentry.*` 6.4.1 → 6.7.0, `EPPlus` 8.6.0 → 8.6.3, `Hangfire` 1.8.23 → 1.8.24, `GoCardless` 9.5.0 → 9.7.0.

### Deliberately not bumped — 30 packages have a new major

Most importantly, **the entire Umbraco 18 family is available**:

| Package | Pinned | Latest |
|---|---|---|
| `Umbraco.Cms` (+ `.Core`, `.Web.Common`, `.Web.Website`) | 17.3.5 | **18.0.2** |
| `Umbraco.Forms` (+ `.Core`, `.StaticAssets`) | 17.0.1 | 18.0.4 |
| `Umbraco.Engage` (+ `.StaticAssets`) | 17.2.2 | 18.0.0 |
| `Umbraco.UIBuilder` / `Umbraco.Workflow` / `uSync.Complete` / `uSync.Forms` | 17.x | 18.x |
| `Umbraco.StorageProviders.AzureBlob` (+ `.ImageSharp`) | 17.0.0 | 18.0.0 |
| `Umbraco.Community.Contentment` | 6.1.4 | 7.0.1 |

Taking those is a migration to Umbraco 18, not a package refresh, and this branch is still settling on 17. Also held back: `SixLabors.ImageSharp` 3.1.12 → 4.0.0, `Refit` 10.2.0 → 14.0.0, `MediatR` 12.5.0 → 14.2.0, `Humanizer.Core` 2.14.1 → 3.0.10, `Stripe.net` 51 → 52, `Razor.Templating.Core` 2.1.0 → 3.1.0, `MaxMind.GeoIP2` 5.4.1 → 6.1.0, `Auth0.ManagementApi` 8.5.0 → 9.1.0, `Microsoft.Extensions.Http.Polly` 8.0.17 → 10.0.10, `Microsoft.CodeAnalysis.Workspaces.MSBuild` 4.14.0 → 5.6.0, `Our.Umbraco.GMaps` 17.0.0 → 18.0.0. Each wants its own PR and its own verification.

### Redundant references removed — 4

| Project | Removed | Supplied by |
|---|---|---|
| `Authentication.Auth0` | `Microsoft.IdentityModel.Tokens` | `Microsoft.IdentityModel.JsonWebTokens` |
| `Data` | `AngleSharp` | `HtmlSanitizer` |
| `Extensions` | `Refit` | `Refit.Newtonsoft.Json` |
| `Storage.Azure` | `SixLabors.ImageSharp.Web.Providers.Azure` | `Umbraco.StorageProviders.AzureBlob.ImageSharp` |

Each was checked both ways — the package is a declared dependency of a sibling reference *in the same project*, **and** no file in that project uses a type from it.

### Redundant but kept — 12

Twelve more references are transitively available but **used directly in code**, so they stay: `Auth0.AuthenticationApi` (3 files), `Microsoft.IdentityModel.Protocols.OpenIdConnect` (2), `Microsoft.Extensions.DependencyInjection.Abstractions` (1), `Humanizer.Core` (20), `NodaTime` (29), `Umbraco.Cms.Core` (**188**), `Umbraco.Cms.Web.Common` (6), `Umbraco.Cms.Web.Website` (2), `AngleSharp` in EditorJs (1), `Hangfire.SqlServer` (1), `Umbraco.StorageProviders.AzureBlob` (3).

A project that compiles against a package should say so rather than lean on whichever dependency happens to carry it. `Umbraco.Cms.Core` is the clearest case — it currently arrives via `Umbraco.Community.Contentment`, and relying on a third-party plugin to supply the CMS would be a bad trade.

## Test plan

This is a mechanical change and every version was confirmed to exist as a stable release on nuget.org, but nothing here is verified by a build: `v17` does not restore end to end (pre-existing `DemoSite` NU1201) and the repo has no PR CI.

- [ ] `dotnet restore` on `src/N3O.Umbraco.sln` produces no new NU1102 (package not found), NU1605 (downgrade) or NU1608 (constraint) beyond the pre-existing `DemoSite` NU1201
- [ ] The four removals resolve to the same versions as before — each now inherits its version from the parent package rather than stating one
- [ ] `Umbraco.Cms` and friends still resolve to 17.3.5, not 18.x
- [ ] `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation` resolves to a single 10.0.10 across `Blocks` and `Cms`
- [ ] `cd src && npm ci && npx turbo run build --env-mode=loose` unaffected (no frontend change in this PR)
- [ ] Smoke-test a backoffice against the refreshed packages before this reaches a release branch

no-work-issue

Routine dependency maintenance across the repo rather than work against a tracked issue.
