### PR TITLE
Migrate N3O.Umbraco.Bundling to Umbraco 17 / .NET 10 (keep Smidge)

### DIFF
--- a/src/Bundling/N3O.Umbraco.Bundling/BundlingComposer.cs
+++ b/src/Bundling/N3O.Umbraco.Bundling/BundlingComposer.cs
@@ -10,12 +10,10 @@ namespace N3O.Umbraco.Bundling;
 
 public class BundlingComposer : Composer {
     public override void Compose(IUmbracoBuilder builder) {
-        // Umbraco 17 dropped Smidge from core. AddRuntimeMinifier() (Umbraco.Community.Smidge) re-registers
-        // Smidge, including the SmidgeHelper this package's Bundler depends on. See n3oltd/work#3211.
+        // Umbraco 17 dropped Smidge from core; re-register it (incl. the SmidgeHelper the Bundler uses). n3oltd/work#3211
         builder.AddRuntimeMinifier();
 
-        // Core also used to add Smidge's request pipeline (which serves the generated bundle URLs); re-add it
-        // here so consuming sites need no change. TODO verify placement on a running site (render check, #3211).
+        // Re-add Smidge's request pipeline (core used to); placement to verify next phase. n3oltd/work#3211
         builder.Services.Configure<UmbracoPipelineOptions>(options => {
             options.AddFilter(new UmbracoPipelineFilter(nameof(BundlingComposer)) {
                 PostRouting = app => app.UseSmidge()

--- a/src/Bundling/N3O.Umbraco.Bundling/BundlingComposer.cs
+++ b/src/Bundling/N3O.Umbraco.Bundling/BundlingComposer.cs
@@ -13,6 +13,9 @@ using Umbraco.Extensions;
 
 namespace N3O.Umbraco.Bundling;
 
+// Umbraco removed the runtime minifier in v14 and points at frontend build tooling (Vite) instead, so this
+// package is a migration candidate: it stays on Smidge only to unblock the v17 migration, and moving the sites
+// to Vite bundling is a per-site job to be done once that migration has landed. n3oltd/work#3211
 public class BundlingComposer : Composer {
     // Umbraco 13 bound Smidge to this section, but Umbraco.Community.Smidge binds a top-level "smidge" section
     // instead, so bind it back to keep the sites' existing settings applying. n3oltd/work#3211

--- a/src/Bundling/N3O.Umbraco.Bundling/BundlingComposer.cs
+++ b/src/Bundling/N3O.Umbraco.Bundling/BundlingComposer.cs
@@ -1,14 +1,29 @@
 using Microsoft.Extensions.DependencyInjection;
 using N3O.Umbraco.Composing;
 using N3O.Umbraco.Extensions;
+using Smidge;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Web.Common.ApplicationBuilder;
+using Umbraco.Community.Smidge;
 
 namespace N3O.Umbraco.Bundling;
 
 public class BundlingComposer : Composer {
     public override void Compose(IUmbracoBuilder builder) {
+        // Umbraco 17 dropped Smidge from core. AddRuntimeMinifier() (Umbraco.Community.Smidge) re-registers
+        // Smidge, including the SmidgeHelper this package's Bundler depends on. See n3oltd/work#3211.
+        builder.AddRuntimeMinifier();
+
+        // Core also used to add Smidge's request pipeline (which serves the generated bundle URLs); re-add it
+        // here so consuming sites need no change. TODO verify placement on a running site (render check, #3211).
+        builder.Services.Configure<UmbracoPipelineOptions>(options => {
+            options.AddFilter(new UmbracoPipelineFilter(nameof(BundlingComposer)) {
+                PostRouting = app => app.UseSmidge()
+            });
+        });
+
         builder.Services.AddScoped<IBundler, Bundler>();
-        
+
         RegisterAll(t => t.ImplementsInterface<IAssetBundle>(),
                     t => builder.Services.AddTransient(typeof(IAssetBundle), t));
     }

--- a/src/Bundling/N3O.Umbraco.Bundling/BundlingComposer.cs
+++ b/src/Bundling/N3O.Umbraco.Bundling/BundlingComposer.cs
@@ -1,28 +1,60 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using N3O.Umbraco.Composing;
 using N3O.Umbraco.Extensions;
 using Smidge;
+using Smidge.Nuglify;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
 using Umbraco.Community.Smidge;
+using Umbraco.Extensions;
 
 namespace N3O.Umbraco.Bundling;
 
 public class BundlingComposer : Composer {
+    // Umbraco 13 bound Smidge to this section, but Umbraco.Community.Smidge binds a top-level "smidge" section
+    // instead, so bind it back to keep the sites' existing settings applying. n3oltd/work#3211
+    private const string RuntimeMinificationSection = "Umbraco:CMS:RuntimeMinification";
+
     public override void Compose(IUmbracoBuilder builder) {
-        // Umbraco 17 dropped Smidge from core; re-register it (incl. the SmidgeHelper the Bundler uses). n3oltd/work#3211
+        // Umbraco 17 dropped Smidge from core; re-register it, incl. the SmidgeHelper the Bundler uses.
+        // n3oltd/work#3211
         builder.AddRuntimeMinifier();
 
-        // Re-add Smidge's request pipeline (core used to); placement to verify next phase. n3oltd/work#3211
-        builder.Services.Configure<UmbracoPipelineOptions>(options => {
-            options.AddFilter(new UmbracoPipelineFilter(nameof(BundlingComposer)) {
-                PostRouting = app => app.UseSmidge()
-            });
-        });
+        // Umbraco 13 replaced Smidge's request helper because Brotli compression is very slow; the community
+        // package ships the replacement but does not register it
+        builder.Services.AddUnique<IRequestHelper, SmidgeRequestHelper>();
+
+        builder.Services.Configure<RuntimeMinificationSettings>(builder.Config.GetSection(RuntimeMinificationSection));
+        builder.Services.ConfigureOptions<OurSmidgeOptions>();
+
+        RegisterMiddleware(builder);
 
         builder.Services.AddScoped<IBundler, Bundler>();
 
         RegisterAll(t => t.ImplementsInterface<IAssetBundle>(),
                     t => builder.Services.AddTransient(typeof(IAssetBundle), t));
+    }
+
+    private void RegisterMiddleware(IUmbracoBuilder builder) {
+        builder.Services.Configure<UmbracoPipelineOptions>(opt => {
+            var filter = new UmbracoPipelineFilter("Smidge");
+
+            // UseSmidge and UseSmidgeNuglify are UseEndpoints calls, so they belong in the endpoints phase, which
+            // is where Umbraco 13 added them (UseBackOfficeEndpoints); adding them any earlier puts a terminating
+            // EndpointMiddleware in front of authentication and authorization
+            filter.Endpoints = app => {
+                var runtimeState = app.ApplicationServices.GetRequiredService<IRuntimeState>();
+
+                if (runtimeState.Level == RuntimeLevel.Run) {
+                    app.UseSmidge();
+                    app.UseSmidgeNuglify();
+                }
+            };
+
+            opt.AddFilter(filter);
+        });
     }
 }

--- a/src/Bundling/N3O.Umbraco.Bundling/N3O.Umbraco.Bundling.csproj
+++ b/src/Bundling/N3O.Umbraco.Bundling/N3O.Umbraco.Bundling.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <RootNamespace>N3O.Umbraco.Bundling</RootNamespace>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>12</LangVersion>
         <Copyright>Copyright © 2026 N3O Ltd</Copyright>
         <NoWarn>1591;NU1605;NU1504</NoWarn>
@@ -21,7 +21,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageProjectUrl>https://n3o.ltd</PackageProjectUrl>
         <RepositoryUrl>https://github.com/n3oltd/umbraco-extensions</RepositoryUrl>
-        <Version>13.0.0</Version>
+        <Version>17.0.0</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
         <FileVersion>$(Version)</FileVersion>
         <RepositoryType>git</RepositoryType>
@@ -40,6 +40,19 @@
             <Pack>True</Pack>
         </None>
     </ItemGroup>
+    <!--
+        v17 migration: Umbraco 17 removed Smidge from the CMS core, so it is no longer available transitively
+        (Umbraco 13 supplied it via Umbraco.Cms). Smidge is KEPT rather than dropped because 5 sites still
+        render their CSS/JS through this package's <n3o-css-bundle> / <n3o-js-bundle> tag helpers
+        (site-mth, site-mr, site-mpb, site-afh, site-mh) and configure Smidge directly via
+        IConfigureOptions<SmidgeOptions>. Umbraco.Community.Smidge re-wires Smidge for Umbraco 17
+        (its AddRuntimeMinifier() calls AddSmidge, registering the SmidgeHelper this package's Bundler uses);
+        Smidge is referenced explicitly for the SmidgeHelper / ISmidgeRequire types used here.
+        Chosen over WebOptimizer (would break each site's Smidge config) and Vite (per-site migration).
+        See n3oltd/work#3211.
+    -->
     <ItemGroup>
+        <PackageReference Include="Smidge" Version="4.6.0" />
+        <PackageReference Include="Umbraco.Community.Smidge" Version="2.0.0" />
     </ItemGroup>
 </Project>

--- a/src/Bundling/N3O.Umbraco.Bundling/N3O.Umbraco.Bundling.csproj
+++ b/src/Bundling/N3O.Umbraco.Bundling/N3O.Umbraco.Bundling.csproj
@@ -40,11 +40,12 @@
             <Pack>True</Pack>
         </None>
     </ItemGroup>
-    <!-- Umbraco 17 dropped Smidge from core; kept because 5 sites use this package's
-         <n3o-css-bundle> / <n3o-js-bundle> tag helpers. Re-wired via Umbraco.Community.Smidge —
-         runtime wiring to be verified in the next phase. n3oltd/work#3211 -->
+    <!-- Umbraco 17 dropped Smidge from core; kept because 4 sites reference this package's
+         <n3o-css-bundle> / <n3o-js-bundle> tag helpers. Re-wired via Umbraco.Community.Smidge; Smidge and
+         Smidge.Nuglify are explicit because the types and middleware here are used directly. n3oltd/work#3211 -->
     <ItemGroup>
         <PackageReference Include="Smidge" Version="4.6.0" />
+        <PackageReference Include="Smidge.Nuglify" Version="4.6.0" />
         <PackageReference Include="Umbraco.Community.Smidge" Version="2.0.0" />
     </ItemGroup>
 </Project>

--- a/src/Bundling/N3O.Umbraco.Bundling/N3O.Umbraco.Bundling.csproj
+++ b/src/Bundling/N3O.Umbraco.Bundling/N3O.Umbraco.Bundling.csproj
@@ -40,17 +40,9 @@
             <Pack>True</Pack>
         </None>
     </ItemGroup>
-    <!--
-        v17 migration: Umbraco 17 removed Smidge from the CMS core, so it is no longer available transitively
-        (Umbraco 13 supplied it via Umbraco.Cms). Smidge is KEPT rather than dropped because 5 sites still
-        render their CSS/JS through this package's <n3o-css-bundle> / <n3o-js-bundle> tag helpers
-        (site-mth, site-mr, site-mpb, site-afh, site-mh) and configure Smidge directly via
-        IConfigureOptions<SmidgeOptions>. Umbraco.Community.Smidge re-wires Smidge for Umbraco 17
-        (its AddRuntimeMinifier() calls AddSmidge, registering the SmidgeHelper this package's Bundler uses);
-        Smidge is referenced explicitly for the SmidgeHelper / ISmidgeRequire types used here.
-        Chosen over WebOptimizer (would break each site's Smidge config) and Vite (per-site migration).
-        See n3oltd/work#3211.
-    -->
+    <!-- Umbraco 17 dropped Smidge from core; kept because 5 sites use this package's
+         <n3o-css-bundle> / <n3o-js-bundle> tag helpers. Re-wired via Umbraco.Community.Smidge —
+         runtime wiring to be verified in the next phase. n3oltd/work#3211 -->
     <ItemGroup>
         <PackageReference Include="Smidge" Version="4.6.0" />
         <PackageReference Include="Umbraco.Community.Smidge" Version="2.0.0" />

--- a/src/Bundling/N3O.Umbraco.Bundling/OurSmidgeOptions.cs
+++ b/src/Bundling/N3O.Umbraco.Bundling/OurSmidgeOptions.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Options;
+using Smidge.Cache;
+using Smidge.Options;
+using System;
+using Umbraco.Community.Smidge;
+
+namespace N3O.Umbraco.Bundling;
+
+// Mirrors Umbraco 13's SmidgeOptionsSetup, which Umbraco.Community.Smidge does not carry over, so without this the
+// configured cache buster and in-memory caching never reach the bundles the Bundler generates. n3oltd/work#3211
+public class OurSmidgeOptions : IConfigureOptions<SmidgeOptions> {
+    private readonly IOptions<RuntimeMinificationSettings> _runtimeMinificationSettings;
+
+    public OurSmidgeOptions(IOptions<RuntimeMinificationSettings> runtimeMinificationSettings) {
+        _runtimeMinificationSettings = runtimeMinificationSettings;
+    }
+
+    public void Configure(SmidgeOptions options) {
+        var settings = _runtimeMinificationSettings.Value;
+
+        options.CacheOptions.UseInMemoryCache = settings.UseInMemoryCache ||
+                                                settings.CacheBuster == RuntimeMinificationCacheBuster.Timestamp;
+
+        var cacheBusterType = GetCacheBusterType(settings.CacheBuster);
+
+        if (cacheBusterType != null) {
+            options.DefaultBundleOptions.DebugOptions.SetCacheBusterType(cacheBusterType);
+            options.DefaultBundleOptions.ProductionOptions.SetCacheBusterType(cacheBusterType);
+        }
+    }
+
+    // Version maps to Umbraco.Community.Smidge's own cache buster, which is internal to that package and so cannot
+    // be named here; leaving it unset falls back to Smidge's ConfigCacheBuster. No site configures Version
+    private Type GetCacheBusterType(RuntimeMinificationCacheBuster cacheBuster) {
+        if (cacheBuster == RuntimeMinificationCacheBuster.Timestamp) {
+            return typeof(TimestampCacheBuster);
+        } else if (cacheBuster == RuntimeMinificationCacheBuster.AppDomain) {
+            return typeof(AppDomainLifetimeCacheBuster);
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Migrates **N3O.Umbraco.Bundling** to Umbraco 17 / .NET 10, **keeping Smidge** (Option 1). Part of the v17 migration (#729); tracked in #3211.

## Why keep it (not delete)

A sites-monorepo check found **4 sites reference this package's `<n3o-css-bundle>` / `<n3o-js-bundle>` tag helpers** — site-mth, site-mr, site-mpb, site-afh (`.Core.csproj` + `@addTagHelper` in `_ViewImports.cshtml`). Deleting the package (as the migration branch had) would break their builds. WebOptimizer would break each site's Smidge config; Vite is a per-site migration. Keeping Smidge is the smallest-change path.

Two caveats on that premise, for #3211:

- **site-mh does not reference this package** (no `PackageReference`, no `@addTagHelper`), so the `<n3o-css-bundle>` in its `Layout.cshtml` is inert markup. It *is* the only site with an `IConfigureOptions<SmidgeOptions>` (`OurSmidgeOptions`), which compiles today only off the Smidge that Umbraco 13's `Umbraco.Cms` supplies **transitively**. On U17 that transitive reference is gone, so `MuslimHands.Core` will not compile until site-mh either references Smidge/this package or deletes `OurSmidgeOptions` — and on v17 the backoffice no longer runs on Smidge, so deleting it is likely correct.
- **The tag helpers currently emit nothing.** There is no `IAssetBundle` implementation and no `IBundler.RequiresCss`/`RequiresJs` caller in this repo or the sites monorepo, and the no-arg `SmidgeHelper.GenerateCssUrlsAsync()`/`GenerateJsUrlsAsync()` only emit *dynamically registered* files — so `Bundler` returns empty and both tag helpers hit `SuppressOutput()`. Any end-to-end verification must register a bundle first, or it proves nothing.

## Changes (this repo only — sites untouched)

- `net8` → `net10`; `Version` 13.0.0 → 17.0.0.
- Umbraco 17 dropped Smidge from core (it used to arrive transitively via `Umbraco.Cms`), so add it back: **`Umbraco.Community.Smidge` 2.0.0** (re-wires Smidge for U17) + **`Smidge` 4.6.0** and **`Smidge.Nuglify` 4.6.0** explicit, since the types and middleware used here are used directly.
- `BundlingComposer`: `builder.AddRuntimeMinifier()` (registers Smidge incl. the `SmidgeHelper` the `Bundler` injects), plus Smidge's request pipeline via an `UmbracoPipelineFilter`.
  - **`UseSmidge()` / `UseSmidgeNuglify()` go in the `Endpoints` phase, not `PostRouting`.** In Smidge 4.6.0 both are `UseEndpoints(...)` calls, and Umbraco's `RegisterDefaultRequiredMiddleware()` runs `RunPostRouting()` *between* `UseRouting()` and `UseAuthentication()`/`UseAuthorization()`/`UseAntiforgery()` — its own comment says "DO NOT PUT ANY UseEndpoints declarations here!! … endpoints are terminating middleware". Placing them there puts a terminating `EndpointMiddleware` in front of auth, so every endpoint with authorization metadata throws (`InvalidOperationException: … contains authorization metadata, but a middleware was not found that supports authorization`) — i.e. the whole backoffice — and anonymous endpoints execute before authentication, localization, session and the `PostPipeline` middleware. Umbraco 13 added Smidge in the endpoints phase (`UseBackOfficeEndpoints` → `UseUmbracoRuntimeMinificationEndpoints`), which is what this now matches.
  - `UseSmidgeNuglify()` is included because core called both; without it the Nuglify source-map route (`{bundlePath}/nmap/{bundle}`) is unmapped while `AddRuntimeMinifier()` still registers the source-map services.
  - Gated on `RuntimeLevel.Run`, matching the other middleware registrations in this repo.
- **`Umbraco:CMS:RuntimeMinification` keeps applying.** `Umbraco.Community.Smidge` binds a top-level `smidge` section, where Umbraco 13 bound `Umbraco:CMS:RuntimeMinification`, and it does not carry over Umbraco's `SmidgeOptionsSetup`. All four consuming sites set `{ "useInMemoryCache": true, "cacheBuster": "Timestamp" }` under the Umbraco path, so without this those values would be silently dropped (defaults are `UseInMemoryCache = false`, `CacheBuster = Version`) — changing bundles from in-memory to physical disk cache and cache-busting from per-restart timestamp to a version hash. Fixed by binding `RuntimeMinificationSettings` to the Umbraco section and adding `OurSmidgeOptions : IConfigureOptions<SmidgeOptions>`, which mirrors Umbraco 13's `SmidgeOptionsSetup`.
- Registers `SmidgeRequestHelper` as the unique `IRequestHelper`, which Umbraco 13 did "to discourage the use of brotli since it's super slow"; the community package ships the type but never registers it.
- `Bundler` / `CssBundleTagHelper` / `JsBundleTagHelper` / `IAssetBundle` unchanged (Smidge 4.6.0 API is unchanged from 4.x).

## Verification

- `dotnet build N3O.Umbraco.Bundling` = **0 errors**, no compiler warnings.
- The pipeline-phase defect and the fix were reproduced in a minimal ASP.NET Core 10 app: with the `UseEndpoints` call between `UseRouting()` and `UseAuthorization()`, an authorized endpoint returns **500** with the authorization-metadata `InvalidOperationException` while the bundle URL serves 200; moved after auth (the `Endpoints` phase), the same authorized endpoint correctly returns **302** (challenge) and the bundle URL still serves 200.
- ⚠️ **Still unverified end-to-end on a running site:** that the sites' `OurSmidgeOptions` still applies, and that a real bundle serves. Note the tag helpers emit nothing until a bundle is registered (see above), so this needs a test bundle. No PR CI in this repo; `v17` doesn't restore end to end.

## Follow-ups for #3211

- **Vite is the intended destination, not Smidge.** Umbraco removed the runtime minifier in v14 and points at frontend build tooling (Vite) instead, so this package is a migration candidate: keeping Smidge only unblocks the v17 migration, and moving the sites to Vite bundling is a per-site job to be done once that migration has landed. Noted in `BundlingComposer` so it isn't lost.
- site-mh: decide between deleting `OurSmidgeOptions` or adding a Smidge reference (it will not compile on v17 as-is).
- Sites must **not** also call `.AddRuntimeMinifier()` in `Program.cs` as the package README suggests — this composer now does it, and `AddSmidge` registers pre-processors and cache busters with plain `AddSingleton`, so a second call duplicates them.
- Not carried over from Umbraco 13: the custom `ISmidgeFileProvider` that let bundles include `/App_Plugins/**/*.{js,css}` from the content root (its `SmidgeFileProvider` / `GlobPatternFilterFileProvider` types are gone in v17 and would have to be reimplemented). No impact while no bundles exist.
- `cacheBuster: "Version"` cannot be mapped faithfully: it resolves to the community package's own cache buster, which is `internal` to that package, so it falls back to Smidge's `ConfigCacheBuster`. No site configures `Version`.

re n3oltd/work#3211
re n3oltd/work#729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
