### PR TITLE
Fix canonical and og:url on virtually-routed pages, missing homepage and sitemap BOM

### DIFF
--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms.Search/Services/CampaignOfferingsSitemapEntriesProvider.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms.Search/Services/CampaignOfferingsSitemapEntriesProvider.cs
@@ -1,14 +1,13 @@
-using Microsoft.AspNetCore.Hosting;
 using N3O.Umbraco.Cloud.Extensions;
 using N3O.Umbraco.Cloud.Lookups;
 using N3O.Umbraco.Cloud.Platforms.Clients;
 using N3O.Umbraco.Cloud.Platforms.Extensions;
-using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Search;
 using N3O.Umbraco.Search.Models;
+using N3O.Umbraco.Utilities;
 using NodaTime;
-using Slugify;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,22 +19,16 @@ public class CampaignOfferingsSitemapEntriesProvider : ISitemapEntriesProvider {
 
     private readonly ICdnClient _cdnClient;
     private readonly IClock _clock;
-    private readonly IContentCache _contentCache;
-    private readonly ISlugHelper _slugHelper;
-    private readonly IWebHostEnvironment _webHostEnvironment;
+    private readonly IUrlBuilder _urlBuilder;
     private readonly ICampaignOfferingVisibility _visibility;
 
     public CampaignOfferingsSitemapEntriesProvider(ICdnClient cdnClient,
                                                    IClock clock,
-                                                   IContentCache contentCache,
-                                                   ISlugHelper slugHelper,
-                                                   IWebHostEnvironment webHostEnvironment,
+                                                   IUrlBuilder urlBuilder,
                                                    ICampaignOfferingVisibility visibility) {
         _cdnClient = cdnClient;
         _clock = clock;
-        _contentCache = contentCache;
-        _slugHelper = slugHelper;
-        _webHostEnvironment = webHostEnvironment;
+        _urlBuilder = urlBuilder;
         _visibility = visibility;
     }
 
@@ -53,11 +46,11 @@ public class CampaignOfferingsSitemapEntriesProvider : ISitemapEntriesProvider {
                 continue;
             }
 
-            entries.Add(GetSitemapEntryForCampaign(publishedCampaign, today));
+            AddSitemapEntry(entries, publishedCampaign.Url, today);
 
             foreach (var publishedOffering in publishedCampaign.Offerings.OrEmpty()) {
                 if (_visibility.IsVisible(publishedOffering)) {
-                    entries.Add(GetSitemapEntryForOffering(publishedOffering, publishedCampaign, today));
+                    AddSitemapEntry(entries, publishedOffering.Url, today);
                 }
             }
         }
@@ -65,20 +58,13 @@ public class CampaignOfferingsSitemapEntriesProvider : ISitemapEntriesProvider {
         return entries;
     }
 
-    private SitemapEntry GetSitemapEntryForCampaign(PublishedCampaign publishedCampaign, LocalDate today) {
-        var url = _contentCache.GetCampaignUrl(_slugHelper, _webHostEnvironment, publishedCampaign.Name);
+    private void AddSitemapEntry(List<SitemapEntry> entries, Uri publishedUrl, LocalDate today) {
+        var url = publishedUrl.RebaseOnSiteRoot(_urlBuilder);
 
-        return new SitemapEntry(url, null, AppealsSection, today, null);
-    }
+        if (!url.HasValue()) {
+            return;
+        }
 
-    private SitemapEntry GetSitemapEntryForOffering(PublishedOffering publishedOffering,
-                                                    PublishedCampaign publishedCampaign,
-                                                    LocalDate today) {
-        var url = _contentCache.GetOfferingUrl(_slugHelper,
-                                               _webHostEnvironment,
-                                               publishedCampaign.Name,
-                                               publishedOffering.Name);
-
-        return new SitemapEntry(url, null, AppealsSection, today, null);
+        entries.Add(new SitemapEntry(url, null, AppealsSection, today, null));
     }
 }

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/ContentLocatorExtensions.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/ContentLocatorExtensions.cs
@@ -1,9 +1,7 @@
 using Flurl;
-using Microsoft.AspNetCore.Hosting;
 using N3O.Umbraco.Cloud.Platforms.Lookups;
 using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
-using N3O.Umbraco.Utilities;
 using Slugify;
 
 namespace N3O.Umbraco.Cloud.Platforms.Extensions;
@@ -25,24 +23,6 @@ public static class ContentLocatorExtensions {
         }
     }
     
-    public static string GetCampaignUrl(this IContentCache contentCache,
-                                        ISlugHelper slugHelper,
-                                        IWebHostEnvironment webHostEnvironment,
-                                        string name) {
-        var campaignPath = GetCampaignPath(contentCache, slugHelper, name);
-        var baseUrl = contentCache.Single<UrlSettingsContent>().BaseUrl(webHostEnvironment);
-
-        if (campaignPath.HasValue()) {
-            var campaignUrl = new Url(baseUrl);
-
-            campaignUrl.AppendPathSegment(campaignPath);
-
-            return campaignUrl;
-        } else {
-            return null;
-        }
-    }
-    
     public static string GetOfferingPath(this IContentCache contentCache,
                                          ISlugHelper slugHelper,
                                          string campaignName,
@@ -54,25 +34,6 @@ public static class ContentLocatorExtensions {
             var offeringUrl = new Url(campaignUrl);
 
             offeringUrl.AppendPathSegment(offeringSlug);
-
-            return offeringUrl;
-        } else {
-            return null;
-        }
-    }
-    
-    public static string GetOfferingUrl(this IContentCache contentCache,
-                                        ISlugHelper slugHelper,
-                                        IWebHostEnvironment webHostEnvironment,
-                                        string campaignName,
-                                        string offeringName) {
-        var offeringPath = GetOfferingPath(contentCache, slugHelper, campaignName, offeringName);
-        var baseUrl = contentCache.Single<UrlSettingsContent>().BaseUrl(webHostEnvironment);
-
-        if (offeringPath.HasValue()) {
-            var offeringUrl = new Url(baseUrl);
-
-            offeringUrl.AppendPathSegment(offeringPath);
 
             return offeringUrl;
         } else {

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/PlatformsPageExtensions.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/PlatformsPageExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Flurl;
-using Humanizer;
+﻿using Humanizer;
 using N3O.Umbraco.Cloud.Lookups;
 using N3O.Umbraco.Cloud.Platforms.Clients;
 using N3O.Umbraco.Cloud.Platforms.Models;
@@ -15,14 +14,7 @@ public static class PlatformsPageExtensions {
             return null;
         }
 
-        var rootUrl = urlBuilder.Root();
-        var url = new Url(page.Url.AbsolutePath);
-
-        url.Scheme = rootUrl.Scheme;
-        url.Host = rootUrl.Host;
-        url.Port = rootUrl.Port;
-
-        return url;
+        return page.Url.RebaseOnSiteRoot(urlBuilder);
     }
 
     public static string GetCampaignId(this PlatformsPage page) {

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/PlatformsPageExtensions.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/PlatformsPageExtensions.cs
@@ -1,12 +1,30 @@
-﻿using Humanizer;
+﻿using Flurl;
+using Humanizer;
 using N3O.Umbraco.Cloud.Lookups;
 using N3O.Umbraco.Cloud.Platforms.Clients;
 using N3O.Umbraco.Cloud.Platforms.Models;
 using N3O.Umbraco.Exceptions;
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Utilities;
 
 namespace N3O.Umbraco.Cloud.Platforms.Extensions;
 
 public static class PlatformsPageExtensions {
+    public static string AbsoluteUrl(this PlatformsPage page, IUrlBuilder urlBuilder) {
+        if (!page.HasValue(x => x.Url)) {
+            return null;
+        }
+
+        var rootUrl = urlBuilder.Root();
+        var url = new Url(page.Url.AbsolutePath);
+
+        url.Scheme = rootUrl.Scheme;
+        url.Host = rootUrl.Host;
+        url.Port = rootUrl.Port;
+
+        return url;
+    }
+
     public static string GetCampaignId(this PlatformsPage page) {
         if (page.Kind == PublishedFileKinds.CampaignPage) {
             return page.Content[nameof(PublishedCampaignPage.Campaign).Camelize()]?[nameof(PublishedCampaignPage.Campaign.Id).Camelize()]?.ToString();

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/PublishedContentExtensions.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/PublishedContentExtensions.cs
@@ -18,8 +18,6 @@ public static class PublishedContentExtensions {
             return false;
         }
 
-        return content.Id == contentCache.Special(PlatformsSpecialPages.Campaign)?.Id ||
-               content.Id == contentCache.Special(PlatformsSpecialPages.Crowdfunder)?.Id ||
-               content.Id == contentCache.Special(PlatformsSpecialPages.Offering)?.Id;
+        return PlatformsSpecialPages.All.Any(x => content.Id == contentCache.Special(x)?.Id);
     }
 }

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/PublishedContentExtensions.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/PublishedContentExtensions.cs
@@ -18,8 +18,8 @@ public static class PublishedContentExtensions {
             return false;
         }
 
-        return content.ContentType.Alias.IsAnyOf(contentCache.Special(PlatformsSpecialPages.Campaign)?.ContentType.Alias,
-                                                 contentCache.Special(PlatformsSpecialPages.Crowdfunder)?.ContentType.Alias,
-                                                 contentCache.Special(PlatformsSpecialPages.Offering)?.ContentType.Alias);
+        return content.Id == contentCache.Special(PlatformsSpecialPages.Campaign)?.Id ||
+               content.Id == contentCache.Special(PlatformsSpecialPages.Crowdfunder)?.Id ||
+               content.Id == contentCache.Special(PlatformsSpecialPages.Offering)?.Id;
     }
 }

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/PublishedContentExtensions.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/PublishedContentExtensions.cs
@@ -1,4 +1,5 @@
-﻿using N3O.Umbraco.Content;
+﻿using N3O.Umbraco.Cloud.Platforms.Lookups;
+using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,5 +11,15 @@ namespace N3O.Umbraco.Cloud.Platforms.Extensions;
 public static class PublishedContentExtensions {
     public static IEnumerable<T> GetDescendantsOfCompositionTypeAs<T>(this IPublishedContent content) {
         return content.Descendants().Where(x => x.IsComposedOf(AliasHelper<T>.ContentTypeAlias())).As<T>();
+    }
+
+    public static bool IsPlatformsPage(this IPublishedContent content, IContentCache contentCache) {
+        if (content == null) {
+            return false;
+        }
+
+        return content.ContentType.Alias.IsAnyOf(contentCache.Special(PlatformsSpecialPages.Campaign)?.ContentType.Alias,
+                                                 contentCache.Special(PlatformsSpecialPages.Crowdfunder)?.ContentType.Alias,
+                                                 contentCache.Special(PlatformsSpecialPages.Offering)?.ContentType.Alias);
     }
 }

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/UriExtensions.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/UriExtensions.cs
@@ -1,0 +1,22 @@
+using Flurl;
+using N3O.Umbraco.Utilities;
+using System;
+
+namespace N3O.Umbraco.Cloud.Platforms.Extensions;
+
+public static class UriExtensions {
+    public static string RebaseOnSiteRoot(this Uri url, IUrlBuilder urlBuilder) {
+        if (url == null) {
+            return null;
+        }
+
+        var rootUrl = urlBuilder.Root();
+        var rebasedUrl = new Url(url.AbsolutePath);
+
+        rebasedUrl.Scheme = rootUrl.Scheme;
+        rebasedUrl.Host = rootUrl.Host;
+        rebasedUrl.Port = rootUrl.Port;
+
+        return rebasedUrl;
+    }
+}

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/UriExtensions.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Extensions/UriExtensions.cs
@@ -1,4 +1,5 @@
 using Flurl;
+using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Utilities;
 using System;
 
@@ -6,12 +7,12 @@ namespace N3O.Umbraco.Cloud.Platforms.Extensions;
 
 public static class UriExtensions {
     public static string RebaseOnSiteRoot(this Uri url, IUrlBuilder urlBuilder) {
-        if (url == null) {
+        if (!url.HasValue()) {
             return null;
         }
 
         var rootUrl = urlBuilder.Root();
-        var rebasedUrl = new Url(url.AbsolutePath);
+        var rebasedUrl = new Url(url.IsAbsoluteUri ? url.AbsolutePath : url.OriginalString);
 
         rebasedUrl.Scheme = rootUrl.Scheme;
         rebasedUrl.Host = rootUrl.Host;

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Lookups/Pages/PlatformsSpecialPages.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Lookups/Pages/PlatformsSpecialPages.cs
@@ -6,4 +6,6 @@ public class PlatformsSpecialPages : ISpecialContents {
     public static readonly SpecialContent Campaign = new("campaignPage", "Campaign Page", "campaignPage");
     public static readonly SpecialContent Crowdfunder = new("crowdfunderPage", "Crowdfunder Page", "crowdfunderPage");
     public static readonly SpecialContent Offering = new("offeringPage", "Offering Page", "offeringPage");
+
+    public static readonly SpecialContent[] All = [Campaign, Crowdfunder, Offering];
 }

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsCanonicalUrlProvider.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsCanonicalUrlProvider.cs
@@ -1,0 +1,41 @@
+using Flurl;
+using N3O.Umbraco.Canonical;
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Utilities;
+using System.Threading.Tasks;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace N3O.Umbraco.Cloud.Platforms;
+
+public class PlatformsCanonicalUrlProvider : ICanonicalUrlProvider {
+    private readonly IPlatformsPageAccessor _platformsPageAccessor;
+    private readonly IUrlBuilder _urlBuilder;
+
+    public PlatformsCanonicalUrlProvider(IPlatformsPageAccessor platformsPageAccessor, IUrlBuilder urlBuilder) {
+        _platformsPageAccessor = platformsPageAccessor;
+        _urlBuilder = urlBuilder;
+    }
+
+    public async Task<string> GetUrlAsync(IPublishedContent content) {
+        var getPageResult = await _platformsPageAccessor.GetAsync();
+
+        if (!getPageResult.HasValue(x => x.Page?.Url)) {
+            return null;
+        }
+
+        var rootUrl = _urlBuilder.Root();
+        var url = new Url(getPageResult.Page.Url.AbsolutePath);
+
+        url.Scheme = rootUrl.Scheme;
+        url.Host = rootUrl.Host;
+        url.Port = rootUrl.Port;
+
+        return url;
+    }
+
+    public async Task<bool> IsProviderForAsync(IPublishedContent content) {
+        var getPageResult = await _platformsPageAccessor.GetAsync();
+
+        return getPageResult.HasValue(x => x.Page);
+    }
+}

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsCanonicalUrlProvider.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsCanonicalUrlProvider.cs
@@ -3,6 +3,7 @@ using N3O.Umbraco.Cloud.Platforms.Extensions;
 using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Utilities;
+using System;
 using System.Threading.Tasks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
@@ -10,11 +11,11 @@ namespace N3O.Umbraco.Cloud.Platforms;
 
 public class PlatformsCanonicalUrlProvider : ICanonicalUrlProvider {
     private readonly IContentCache _contentCache;
-    private readonly IPlatformsPageAccessor _platformsPageAccessor;
+    private readonly Lazy<IPlatformsPageAccessor> _platformsPageAccessor;
     private readonly IUrlBuilder _urlBuilder;
 
     public PlatformsCanonicalUrlProvider(IContentCache contentCache,
-                                         IPlatformsPageAccessor platformsPageAccessor,
+                                         Lazy<IPlatformsPageAccessor> platformsPageAccessor,
                                          IUrlBuilder urlBuilder) {
         _contentCache = contentCache;
         _platformsPageAccessor = platformsPageAccessor;
@@ -22,7 +23,7 @@ public class PlatformsCanonicalUrlProvider : ICanonicalUrlProvider {
     }
 
     public async Task<string> GetUrlAsync(IPublishedContent content) {
-        var getPageResult = await _platformsPageAccessor.GetAsync();
+        var getPageResult = await _platformsPageAccessor.Value.GetAsync();
 
         if (!getPageResult.HasValue(x => x.Page)) {
             return null;

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsCanonicalUrlProvider.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsCanonicalUrlProvider.cs
@@ -1,5 +1,6 @@
-using Flurl;
 using N3O.Umbraco.Canonical;
+using N3O.Umbraco.Cloud.Platforms.Extensions;
+using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Utilities;
 using System.Threading.Tasks;
@@ -8,10 +9,14 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 namespace N3O.Umbraco.Cloud.Platforms;
 
 public class PlatformsCanonicalUrlProvider : ICanonicalUrlProvider {
+    private readonly IContentCache _contentCache;
     private readonly IPlatformsPageAccessor _platformsPageAccessor;
     private readonly IUrlBuilder _urlBuilder;
 
-    public PlatformsCanonicalUrlProvider(IPlatformsPageAccessor platformsPageAccessor, IUrlBuilder urlBuilder) {
+    public PlatformsCanonicalUrlProvider(IContentCache contentCache,
+                                         IPlatformsPageAccessor platformsPageAccessor,
+                                         IUrlBuilder urlBuilder) {
+        _contentCache = contentCache;
         _platformsPageAccessor = platformsPageAccessor;
         _urlBuilder = urlBuilder;
     }
@@ -19,23 +24,14 @@ public class PlatformsCanonicalUrlProvider : ICanonicalUrlProvider {
     public async Task<string> GetUrlAsync(IPublishedContent content) {
         var getPageResult = await _platformsPageAccessor.GetAsync();
 
-        if (!getPageResult.HasValue(x => x.Page?.Url)) {
+        if (!getPageResult.HasValue(x => x.Page)) {
             return null;
         }
 
-        var rootUrl = _urlBuilder.Root();
-        var url = new Url(getPageResult.Page.Url.AbsolutePath);
-
-        url.Scheme = rootUrl.Scheme;
-        url.Host = rootUrl.Host;
-        url.Port = rootUrl.Port;
-
-        return url;
+        return getPageResult.Page.AbsoluteUrl(_urlBuilder);
     }
 
-    public async Task<bool> IsProviderForAsync(IPublishedContent content) {
-        var getPageResult = await _platformsPageAccessor.GetAsync();
-
-        return getPageResult.HasValue(x => x.Page);
+    public Task<bool> IsProviderForAsync(IPublishedContent content) {
+        return Task.FromResult(content.IsPlatformsPage(_contentCache));
     }
 }

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsCanonicalUrlProvider.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsCanonicalUrlProvider.cs
@@ -31,7 +31,7 @@ public class PlatformsCanonicalUrlProvider : ICanonicalUrlProvider {
         return getPageResult.Page.AbsoluteUrl(_urlBuilder);
     }
 
-    public Task<bool> IsProviderForAsync(IPublishedContent content) {
-        return Task.FromResult(content.IsPlatformsPage(_contentCache));
+    public bool IsProviderFor(IPublishedContent content) {
+        return content.IsPlatformsPage(_contentCache);
     }
 }

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageOpenGraphProvider.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageOpenGraphProvider.cs
@@ -3,6 +3,7 @@ using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.OpenGraph;
 using N3O.Umbraco.Utilities;
+using System;
 using System.Threading.Tasks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
@@ -10,11 +11,11 @@ namespace N3O.Umbraco.Cloud.Platforms;
 
 public class PlatformsPageOpenGraphProvider : IOpenGraphProvider {
     private readonly IContentCache _contentCache;
-    private readonly IPlatformsPageAccessor _platformsPageAccessor;
+    private readonly Lazy<IPlatformsPageAccessor> _platformsPageAccessor;
     private readonly IUrlBuilder _urlBuilder;
 
     public PlatformsPageOpenGraphProvider(IContentCache contentCache,
-                                          IPlatformsPageAccessor platformsPageAccessor,
+                                          Lazy<IPlatformsPageAccessor> platformsPageAccessor,
                                           IUrlBuilder urlBuilder) {
         _contentCache = contentCache;
         _platformsPageAccessor = platformsPageAccessor;
@@ -22,7 +23,7 @@ public class PlatformsPageOpenGraphProvider : IOpenGraphProvider {
     }
 
     public async Task AddOpenGraphAsync(IOpenGraphBuilder builder, IPublishedContent page) {
-        var getPageResult = await _platformsPageAccessor.GetAsync();
+        var getPageResult = await _platformsPageAccessor.Value.GetAsync();
 
         if (getPageResult.HasValue(x => x.Page)) {
             builder.WithUrl(getPageResult.Page.AbsoluteUrl(_urlBuilder));

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageOpenGraphProvider.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageOpenGraphProvider.cs
@@ -1,0 +1,35 @@
+using N3O.Umbraco.Cloud.Platforms.Extensions;
+using N3O.Umbraco.Content;
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.OpenGraph;
+using N3O.Umbraco.Utilities;
+using System.Threading.Tasks;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace N3O.Umbraco.Cloud.Platforms;
+
+public class PlatformsPageOpenGraphProvider : IOpenGraphProvider {
+    private readonly IContentCache _contentCache;
+    private readonly IPlatformsPageAccessor _platformsPageAccessor;
+    private readonly IUrlBuilder _urlBuilder;
+
+    public PlatformsPageOpenGraphProvider(IContentCache contentCache,
+                                          IPlatformsPageAccessor platformsPageAccessor,
+                                          IUrlBuilder urlBuilder) {
+        _contentCache = contentCache;
+        _platformsPageAccessor = platformsPageAccessor;
+        _urlBuilder = urlBuilder;
+    }
+
+    public async Task AddOpenGraphAsync(IOpenGraphBuilder builder, IPublishedContent page) {
+        var getPageResult = await _platformsPageAccessor.GetAsync();
+
+        if (getPageResult.HasValue(x => x.Page)) {
+            builder.WithUrl(getPageResult.Page.AbsoluteUrl(_urlBuilder));
+        }
+    }
+
+    public bool IsProviderFor(IPublishedContent page) {
+        return page.IsPlatformsPage(_contentCache);
+    }
+}

--- a/src/N3O.Umbraco.Extensions/Canonical/CanonicalComposer.cs
+++ b/src/N3O.Umbraco.Extensions/Canonical/CanonicalComposer.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using N3O.Umbraco.Composing;
+using N3O.Umbraco.Extensions;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace N3O.Umbraco.Canonical;
+
+public class CanonicalComposer : Composer {
+    public override void Compose(IUmbracoBuilder builder) {
+        RegisterAll(t => t.ImplementsInterface<ICanonicalUrlProvider>(),
+                    t => builder.Services.AddTransient(typeof(ICanonicalUrlProvider), t));
+    }
+}

--- a/src/N3O.Umbraco.Extensions/Canonical/CanonicalUrlProvider.I.cs
+++ b/src/N3O.Umbraco.Extensions/Canonical/CanonicalUrlProvider.I.cs
@@ -5,5 +5,5 @@ namespace N3O.Umbraco.Canonical;
 
 public interface ICanonicalUrlProvider {
     Task<string> GetUrlAsync(IPublishedContent content);
-    Task<bool> IsProviderForAsync(IPublishedContent content);
+    bool IsProviderFor(IPublishedContent content);
 }

--- a/src/N3O.Umbraco.Extensions/Canonical/CanonicalUrlProvider.I.cs
+++ b/src/N3O.Umbraco.Extensions/Canonical/CanonicalUrlProvider.I.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace N3O.Umbraco.Canonical;
+
+public interface ICanonicalUrlProvider {
+    Task<string> GetUrlAsync(IPublishedContent content);
+    Task<bool> IsProviderForAsync(IPublishedContent content);
+}

--- a/src/N3O.Umbraco.Extensions/Content/Locator.cs
+++ b/src/N3O.Umbraco.Extensions/Content/Locator.cs
@@ -70,7 +70,7 @@ public abstract class Locator : ILocator {
 
             foreach (var rootContent in c.GetAtRoot()) {
                 if (contentTypeAlias == null) {
-                    allContent.AddRange(rootContent.Descendants());
+                    allContent.AddRange(rootContent.DescendantsOrSelf());
                 } else {
                     if (rootContent.ContentType.Alias.EqualsInvariant(contentTypeAlias)) {
                         allContent.Add(rootContent);

--- a/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.cs
+++ b/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphBuilder.cs
@@ -49,5 +49,5 @@ public class OpenGraphBuilder : IOpenGraphBuilder {
         return new OpenGraphData(_title, _description, _url, _imageUrl);
     }
 
-    public bool HasData => _title.HasValue() || _description.HasValue() || _imageUrl.HasValue();
+    public bool HasData => _title.HasValue() || _description.HasValue() || _url.HasValue() || _imageUrl.HasValue();
 }

--- a/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphPageModule.cs
+++ b/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphPageModule.cs
@@ -20,17 +20,17 @@ public class OpenGraphPageModule : IPageModule {
 
     public bool ShouldExecute(IPublishedContent page) => true;
 
-    public Task<object> ExecuteAsync(IPublishedContent page, CancellationToken cancellationToken) {
+    public async Task<object> ExecuteAsync(IPublishedContent page, CancellationToken cancellationToken) {
         var providers = _allProviders.OrEmpty().Where(x => x.IsProviderFor(page)).ToList();
 
         foreach (var provider in providers) {
-            provider.AddOpenGraph(_openGraphBuilder, page);
+            await provider.AddOpenGraphAsync(_openGraphBuilder, page);
         }
 
         if (_openGraphBuilder.HasData) {
-            return Task.FromResult<object>(_openGraphBuilder.Build());
+            return _openGraphBuilder.Build();
         } else {
-            return Task.FromResult<object>(null);
+            return null;
         }
     }
 

--- a/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphProvider.I.cs
+++ b/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphProvider.I.cs
@@ -1,8 +1,9 @@
+using System.Threading.Tasks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace N3O.Umbraco.OpenGraph;
 
 public interface IOpenGraphProvider {
-    void AddOpenGraph(IOpenGraphBuilder builder, IPublishedContent page);
+    Task AddOpenGraphAsync(IOpenGraphBuilder builder, IPublishedContent page);
     bool IsProviderFor(IPublishedContent page);
 }

--- a/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphProvider.cs
+++ b/src/N3O.Umbraco.Extensions/OpenGraph/OpenGraphProvider.cs
@@ -1,10 +1,13 @@
+using System.Threading.Tasks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace N3O.Umbraco.OpenGraph;
 
 public abstract class OpenGraphProvider<T> : IOpenGraphProvider where T : IPublishedContent {
-    public void AddOpenGraph(IOpenGraphBuilder builder, IPublishedContent page) {
+    public Task AddOpenGraphAsync(IOpenGraphBuilder builder, IPublishedContent page) {
         AddOpenGraph(builder, (T) page);
+
+        return Task.CompletedTask;
     }
 
     public virtual bool IsProviderFor(IPublishedContent page) {

--- a/src/N3O.Umbraco.Extensions/TagHelpers/CanonicalUrlTagHelper.cs
+++ b/src/N3O.Umbraco.Extensions/TagHelpers/CanonicalUrlTagHelper.cs
@@ -1,20 +1,45 @@
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using N3O.Umbraco.Canonical;
 using N3O.Umbraco.Constants;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Pages;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace N3O.Umbraco.TagHelpers;
 
 [HtmlTargetElement($"{Prefixes.TagHelpers}canonical-url")]
 public class CanonicalUrlTagHelper : TagHelper {
+    private readonly IEnumerable<ICanonicalUrlProvider> _allProviders;
+
+    public CanonicalUrlTagHelper(IEnumerable<ICanonicalUrlProvider> allProviders) {
+        _allProviders = allProviders;
+    }
+
     [HtmlAttributeName("model")]
     public IPageViewModel Model { get; set; }
 
-    public override void Process(TagHelperContext context, TagHelperOutput output) {        
+    public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output) {
         output.TagName = "link";
         output.TagMode = TagMode.SelfClosing;
-        
+
+        var url = await GetUrlAsync();
+
         output.Attributes.SetAttribute("rel", "canonical");
-        output.Attributes.SetAttribute("href", Model.Content.AbsoluteUrl());
+        output.Attributes.SetAttribute("href", url);
+    }
+
+    private async Task<string> GetUrlAsync() {
+        foreach (var provider in _allProviders) {
+            if (await provider.IsProviderForAsync(Model.Content)) {
+                var url = await provider.GetUrlAsync(Model.Content);
+
+                if (url.HasValue()) {
+                    return url;
+                }
+            }
+        }
+
+        return Model.Content.AbsoluteUrl();
     }
 }

--- a/src/N3O.Umbraco.Extensions/TagHelpers/CanonicalUrlTagHelper.cs
+++ b/src/N3O.Umbraco.Extensions/TagHelpers/CanonicalUrlTagHelper.cs
@@ -31,7 +31,7 @@ public class CanonicalUrlTagHelper : TagHelper {
     }
 
     private async Task<string> GetUrlAsync() {
-        var providers = _allProviders.OrEmpty().Where(x => x.IsProviderFor(Model.Content));
+        var providers = _allProviders.Where(x => x.IsProviderFor(Model.Content));
 
         foreach (var provider in providers) {
             var url = await provider.GetUrlAsync(Model.Content);

--- a/src/N3O.Umbraco.Extensions/TagHelpers/CanonicalUrlTagHelper.cs
+++ b/src/N3O.Umbraco.Extensions/TagHelpers/CanonicalUrlTagHelper.cs
@@ -4,16 +4,17 @@ using N3O.Umbraco.Constants;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Pages;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace N3O.Umbraco.TagHelpers;
 
 [HtmlTargetElement($"{Prefixes.TagHelpers}canonical-url")]
 public class CanonicalUrlTagHelper : TagHelper {
-    private readonly IEnumerable<ICanonicalUrlProvider> _allProviders;
+    private readonly IReadOnlyList<ICanonicalUrlProvider> _allProviders;
 
     public CanonicalUrlTagHelper(IEnumerable<ICanonicalUrlProvider> allProviders) {
-        _allProviders = allProviders;
+        _allProviders = allProviders.ApplyAttributeOrdering();
     }
 
     [HtmlAttributeName("model")]
@@ -30,13 +31,13 @@ public class CanonicalUrlTagHelper : TagHelper {
     }
 
     private async Task<string> GetUrlAsync() {
-        foreach (var provider in _allProviders) {
-            if (await provider.IsProviderForAsync(Model.Content)) {
-                var url = await provider.GetUrlAsync(Model.Content);
+        var providers = _allProviders.OrEmpty().Where(x => x.IsProviderFor(Model.Content));
 
-                if (url.HasValue()) {
-                    return url;
-                }
+        foreach (var provider in providers) {
+            var url = await provider.GetUrlAsync(Model.Content);
+
+            if (url.HasValue()) {
+                return url;
             }
         }
 

--- a/src/Search/N3O.Umbraco.Search/Extensions/SitemapEntryExtensions.cs
+++ b/src/Search/N3O.Umbraco.Search/Extensions/SitemapEntryExtensions.cs
@@ -128,7 +128,6 @@ public static class SitemapEntryExtensions {
     private static XmlWriterSettings GetWriterSettings() {
         var settings = new XmlWriterSettings();
 
-        // Encoding.UTF8 emits a preamble, which the GetString calls above keep, leaving a BOM ahead of the declaration
         settings.Encoding = new UTF8Encoding(false);
         settings.Indent = true;
         settings.OmitXmlDeclaration = false;

--- a/src/Search/N3O.Umbraco.Search/Extensions/SitemapEntryExtensions.cs
+++ b/src/Search/N3O.Umbraco.Search/Extensions/SitemapEntryExtensions.cs
@@ -128,7 +128,7 @@ public static class SitemapEntryExtensions {
     private static XmlWriterSettings GetWriterSettings() {
         var settings = new XmlWriterSettings();
 
-        // Encoding.UTF8 emits a preamble, which GetString below keeps, leaving a BOM ahead of the XML declaration
+        // Encoding.UTF8 emits a preamble, which the GetString calls above keep, leaving a BOM ahead of the declaration
         settings.Encoding = new UTF8Encoding(false);
         settings.Indent = true;
         settings.OmitXmlDeclaration = false;

--- a/src/Search/N3O.Umbraco.Search/Extensions/SitemapEntryExtensions.cs
+++ b/src/Search/N3O.Umbraco.Search/Extensions/SitemapEntryExtensions.cs
@@ -128,7 +128,8 @@ public static class SitemapEntryExtensions {
     private static XmlWriterSettings GetWriterSettings() {
         var settings = new XmlWriterSettings();
 
-        settings.Encoding = Encoding.UTF8;
+        // Encoding.UTF8 emits a preamble, which GetString below keeps, leaving a BOM ahead of the XML declaration
+        settings.Encoding = new UTF8Encoding(false);
         settings.Indent = true;
         settings.OmitXmlDeclaration = false;
 

--- a/src/Validation/N3O.Umbraco.Validation/Hosting/ExceptionMiddleware.cs
+++ b/src/Validation/N3O.Umbraco.Validation/Hosting/ExceptionMiddleware.cs
@@ -53,6 +53,10 @@ public class ExceptionMiddleware : IMiddleware {
                                      endpoint?.ActionName,
                                      ex.Message);
                 }
+                
+                if (context.Response.HasStarted) {
+                    throw;
+                }
 
                 await WriteProblemDetailsAsync(context.Response, problemDetailsException);
             }

--- a/src/Validation/N3O.Umbraco.Validation/Hosting/ExceptionMiddleware.cs
+++ b/src/Validation/N3O.Umbraco.Validation/Hosting/ExceptionMiddleware.cs
@@ -53,7 +53,8 @@ public class ExceptionMiddleware : IMiddleware {
                                      endpoint?.ActionName,
                                      ex.Message);
                 }
-                
+
+                // Headers are already sent, so Response.Clear() below would throw and mask the original exception
                 if (context.Response.HasStarted) {
                     throw;
                 }

--- a/src/Validation/N3O.Umbraco.Validation/Hosting/ExceptionMiddleware.cs
+++ b/src/Validation/N3O.Umbraco.Validation/Hosting/ExceptionMiddleware.cs
@@ -54,7 +54,6 @@ public class ExceptionMiddleware : IMiddleware {
                                      ex.Message);
                 }
 
-                // Headers are already sent, so Response.Clear() below would throw and mask the original exception
                 if (context.Response.HasStarted) {
                     throw;
                 }


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

An audit of a client sitemap (all 504 URLs probed live) turned up several defects in this package. The XML itself was already well-formed — no duplicates, all HTTPS, valid `lastmod` throughout — so everything here is about what the sitemap points at, and what those pages then say about themselves.

**Page URLs for virtually-routed content.** `PlatformsContentFinder` serves every campaign, crowdfunder and offering URL from a single shared content node. Anything deriving a page's address from that node therefore reported the same address for all of them. Two separate places were doing exactly that:

- The canonical tag emitted `Model.Content.AbsoluteUrl()`, so on the audited site all 259 donate pages declared their canonical as `/donate/offering-page` or `/donate/campaign-page` — URLs that are not in the sitemap and that redirect elsewhere. In effect the whole donation funnel told search engines it was one page.
- `og:url` was worse: `IOpenGraphBuilder.WithUrl` was called nowhere in the codebase, so the tag helper always hit its `?? Model.Content.AbsoluteUrl()` fallback and every one of those pages advertised the shared node as its Open Graph URL.

Canonical resolution now goes through an auto-discovered `ICanonicalUrlProvider`, registered like `IMetadataProvider` and `IContentRenderabilityFilter`, and a new `PlatformsPageOpenGraphProvider` supplies `og:url`. Both take the URL the platforms service published for the page. Content that no provider claims still falls back to the content node, which matters — that fallback is what collapses trailing-slash, mixed-case and query-string variants onto one canonical for normally-routed pages, and it is preserved.

`IOpenGraphProvider.AddOpenGraph` becomes `AddOpenGraphAsync` so a provider can await its data. The typed `OpenGraphProvider<T>` base keeps its synchronous `protected abstract void AddOpenGraph` and adapts it, so existing site providers are unaffected; providers that need to await implement the interface directly. `OpenGraphBuilder.HasData` now takes the URL into account too — without that, a provider setting only the URL would leave `HasData` false, the data would never be built, and the URL would be silently dropped.

Two rules that had ended up expressed twice are now shared, so the canonical and Open Graph paths cannot drift apart: `PlatformsPageExtensions.AbsoluteUrl` builds the page URL, and `PublishedContentExtensions.IsPlatformsPage` decides what counts as a virtually-routed platforms page. That check matches on node identity rather than content type alias — the special pages share their doctype with ordinary content, so an alias comparison would have claimed every page using it. Correctness would have survived, because `PlatformsPageAccessor` returns nothing for a request that matches no platforms route, but the providers would have been invoking the accessor on unrelated pages and issuing CDN lookups on the render path of content Umbraco had already routed itself. Identity matching mirrors `PlatformsPageContentVisibilityFilter`.

`ICanonicalUrlProvider.IsProviderFor` is synchronous, matching `IOpenGraphProvider`, and the canonical providers are attribute-ordered the same way `OpenGraphPageModule` orders its own. One predicate, one shape, one ordering rule across both seams.

**Missing root content.** The untyped branch of `Locator.GetAllContent` added `rootContent.Descendants()`, which in Umbraco excludes the node itself, while the typed branch immediately below it explicitly adds the root back when the alias matches. The two branches disagreed, so any caller passing no content type alias never saw root content — which is why the homepage was absent from the sitemap. Non-routable root containers are unaffected: Umbraco returns `"#"` for content it cannot route and the existing `IsRoutable` guard already discards those.

**Sitemap byte order mark.** `XmlWriterSettings.Encoding` was `Encoding.UTF8`, whose preamble is written into the stream, survives the round trip through `Encoding.UTF8.GetString`, and is re-encoded on save — leaving `EF BB BF` ahead of the XML declaration. Google tolerates it, but strict XML consumers treat bytes before the declaration as fatal, which is why third-party validators reject the file.

**Unhandled exceptions during rendering.** `ExceptionMiddleware` called `Response.Clear()` unconditionally. That throws once the response has started, so an exception thrown part-way through rendering a view was replaced by an `InvalidOperationException` and the caller received an empty `500` with no problem details, no content type and no correlation id. The original exception is now rethrown instead, so the real error survives.

## Test plan

- [x] `N3O.Umbraco.sln` builds with 0 errors
- [x] A consuming site solution (on the published package) builds with 0 errors
- [x] BOM fix exercised against the built assembly: `ToXml()` output now begins `3C-3F-78-6D-6C` (`<?xml`) with no `EF-BB-BF` preamble
- [x] URL rebasing checked against Flurl 4.0.0: an `AbsolutePath` of `/donate/current-campaigns/gaza-fund` resolves to `https://<host>/donate/current-campaigns/gaza-fund`
- [x] Existing synchronous `OpenGraphProvider<T>` subclasses still compile against the async interface, verified by compiling a subclass with the unchanged override signature
- [x] Searched every site in the sites monorepo for direct `IOpenGraphProvider` implementers: none exist, both providers derive from the shielded base
- [x] Confirmed against Umbraco 13 source that `Descendants()` passes `orSelf: false`, and that `UrlProvider` returns `"#"` for unroutable content
- [x] Reviewed every predicate-only `Locator.All(...)` caller for fallout from including root nodes: all filter on `IsComposedOf`, `Parent?.Id` or `IsPage`, none of which a root node satisfies
- [ ] Canonical, `og:url`, homepage and middleware changes exercised against a running site — not done, needs a site database and CMS content
- [ ] Regression check that no site's sitemap loses entries once the root node is included

## Notes for the reviewer

`og:title`, `og:description` and `og:image` are still derived from the shared node for virtually-routed pages, since the site-level provider keys off `Model.Content`. Only the URL is addressed here; feeding the rest from the platforms payload would be a separate change.

The rethrow in `ExceptionMiddleware` sits after the existing `LogError` call, so an exception that reaches it is reported here and again by whatever handler catches it upstream. That is deliberate — moving the check above the logging would lose the controller and action context — but it does mean two error-tracker events per occurrence.

A sitemap defect found in the same audit is deliberately **not** addressed here. Content nodes that are not pages were appearing in the sitemap and returning `500` when requested, because a template had been assigned to them before it was removed from their document type — and removing a template from a document type does not clear the `templateId` already stored on existing content. `HasTemplateVisibilityFilter` is working correctly; the stored data is stale, so the fix is a content correction rather than a code change.

`ContentVisibility.IsVisible` calls `.All()` over the filters that match, so content no filter claims is vacuously visible. In practice three framework filters match everything, so the empty case never arises today — but it is worth a decision at some point, and it is left alone here on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
