### PR TITLE
Fix campaign, crowdfunder and offering 404s on culture-varying sites

### DIFF
--- a/src/N3O.Umbraco.Extensions/ContentFinders/ContentFindersComposer.cs
+++ b/src/N3O.Umbraco.Extensions/ContentFinders/ContentFindersComposer.cs
@@ -10,6 +10,8 @@ public class ContentFindersComposer : Composer {
     public override void Compose(IUmbracoBuilder builder) {
         builder.SetContentLastChanceFinder<LastChanceFinder>();
 
+        builder.Components().Append<FlushSpecialContentPathsComponent>();
+
         RegisterAll(t => t.ImplementsInterface<IContentFinder>() &&
                          !t.ImplementsInterface<IContentLastChanceFinder>(),
                     (type, index) => builder.ContentFinders().Insert(index, type));

--- a/src/N3O.Umbraco.Extensions/ContentFinders/FlushSpecialContentPathsComponent.cs
+++ b/src/N3O.Umbraco.Extensions/ContentFinders/FlushSpecialContentPathsComponent.cs
@@ -1,0 +1,25 @@
+using N3O.Umbraco.Content;
+using System;
+using Umbraco.Cms.Core.Composing;
+
+namespace N3O.Umbraco.ContentFinders;
+
+public class FlushSpecialContentPathsComponent : IComponent {
+    private readonly IContentCache _contentCache;
+
+    public FlushSpecialContentPathsComponent(IContentCache contentCache) {
+        _contentCache = contentCache;
+    }
+
+    public void Initialize() {
+        _contentCache.Flushed += ContentCacheOnFlushed;
+    }
+
+    public void Terminate() {
+        _contentCache.Flushed -= ContentCacheOnFlushed;
+    }
+
+    private void ContentCacheOnFlushed(object sender, EventArgs args) {
+        SpecialContentPathParser.Flush();
+    }
+}

--- a/src/N3O.Umbraco.Extensions/ContentFinders/SpecialContentPathParser.cs
+++ b/src/N3O.Umbraco.Extensions/ContentFinders/SpecialContentPathParser.cs
@@ -1,44 +1,97 @@
 ﻿using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
 namespace N3O.Umbraco.ContentFinders;
 
 public static class SpecialContentPathParser {
-    private static readonly Dictionary<SpecialContent, IPublishedContent> SpecialPages = new();
-    private static readonly Dictionary<SpecialContent, string> SpecialPaths = new();
-    
-    public static string GetPath(IContentCache contentCache, SpecialContent specialContent) {
-        var specialPath = SpecialPaths.GetOrAdd(specialContent, () => {
-            var specialPage = GetPage(contentCache, specialContent);
-            
-            if (specialPage.HasValue()) {
-                return specialPage.RelativeUrl().StripTrailingSlash();
-            } else {
-                return null;
-            }
-        });
+    private static readonly ConcurrentDictionary<SpecialContent, IReadOnlyList<string>> SpecialPaths = new();
 
-        return specialPath;
+    public static string GetPath(IContentCache contentCache, SpecialContent specialContent) {
+        var specialPage = contentCache.Special(specialContent);
+
+        if (specialPage.HasValue()) {
+            var ambientPath = specialPage.RelativeUrl().StripTrailingSlash();
+
+            if (IsRoutable(ambientPath)) {
+                return ambientPath;
+            }
+        }
+
+        return GetPaths(contentCache, specialContent).FirstOrDefault();
     }
-    
+
     public static string ParseUri(IContentCache contentCache, SpecialContent specialContent, Uri requestUri) {
-        var specialPath = GetPath(contentCache, specialContent);
         var requestedPath = requestUri.GetAbsolutePathDecoded().ToLowerInvariant().StripTrailingSlash();
-        
-        if (specialPath.HasValue() && requestedPath.StartsWith(specialPath)) {
-            return requestedPath.Substring(specialPath.Length).EnsureTrailingSlash();
-        } else {
-            return null;
+
+        foreach (var specialPath in GetPaths(contentCache, specialContent).OrderByDescending(x => x.Length)) {
+            if (requestedPath.StartsWith(specialPath, StringComparison.OrdinalIgnoreCase)) {
+                return requestedPath.Substring(specialPath.Length).EnsureTrailingSlash();
+            }
+        }
+
+        return null;
+    }
+
+    private static void AddPathIfRoutable(ICollection<string> specialPaths, string url) {
+        if (!url.HasValue()) {
+            return;
+        }
+
+        var path = url.StripTrailingSlash();
+
+        if (IsRoutable(path) && !specialPaths.Contains(path, StringComparer.OrdinalIgnoreCase)) {
+            specialPaths.Add(path);
         }
     }
-    
-    private static IPublishedContent GetPage(IContentCache contentCache, SpecialContent specialContent) {
-        var specialPage = SpecialPages.GetOrAdd(specialContent, () => contentCache.Special(specialContent));
 
-        return specialPage;
+    private static IReadOnlyList<string> GetCultures(IPublishedContent specialPage) {
+        return specialPage.AncestorsOrSelf()
+                          .SelectMany(x => x.Cultures.Keys)
+                          .Distinct()
+                          .ToList();
+    }
+
+    private static IReadOnlyList<string> GetPaths(IContentCache contentCache, SpecialContent specialContent) {
+        if (SpecialPaths.TryGetValue(specialContent, out var cachedPaths)) {
+            return cachedPaths;
+        }
+
+        var specialPage = contentCache.Special(specialContent);
+
+        if (!specialPage.HasValue()) {
+            return [];
+        }
+
+        var specialPaths = GetRoutablePaths(specialPage);
+
+        if (specialPaths.None()) {
+            return [];
+        }
+
+        SpecialPaths.TryAdd(specialContent, specialPaths);
+
+        return specialPaths;
+    }
+
+    private static IReadOnlyList<string> GetRoutablePaths(IPublishedContent specialPage) {
+        var specialPaths = new List<string>();
+
+        AddPathIfRoutable(specialPaths, specialPage.RelativeUrl());
+
+        foreach (var culture in GetCultures(specialPage)) {
+            AddPathIfRoutable(specialPaths, specialPage.Url(culture, UrlMode.Relative));
+        }
+
+        return specialPaths;
+    }
+
+    private static bool IsRoutable(string path) {
+        return path.HasValue() && path.StartsWith('/');
     }
 }

--- a/src/N3O.Umbraco.Extensions/ContentFinders/SpecialContentPathParser.cs
+++ b/src/N3O.Umbraco.Extensions/ContentFinders/SpecialContentPathParser.cs
@@ -12,6 +12,10 @@ namespace N3O.Umbraco.ContentFinders;
 public static class SpecialContentPathParser {
     private static readonly ConcurrentDictionary<SpecialContent, IReadOnlyList<string>> SpecialPaths = new();
 
+    public static void Flush() {
+        SpecialPaths.Clear();
+    }
+
     public static string GetPath(IContentCache contentCache, SpecialContent specialContent) {
         var specialPage = contentCache.Special(specialContent);
 

--- a/src/N3O.Umbraco.Extensions/ContentFinders/SpecialContentPathParser.cs
+++ b/src/N3O.Umbraco.Extensions/ContentFinders/SpecialContentPathParser.cs
@@ -34,7 +34,7 @@ public static class SpecialContentPathParser {
         var requestedPath = requestUri.GetAbsolutePathDecoded().ToLowerInvariant().StripTrailingSlash();
 
         foreach (var specialPath in GetPaths(contentCache, specialContent).OrderByDescending(x => x.Length)) {
-            if (requestedPath.StartsWith(specialPath, StringComparison.OrdinalIgnoreCase)) {
+            if (requestedPath.StartsWith(specialPath, StringComparison.InvariantCultureIgnoreCase)) {
                 return requestedPath.Substring(specialPath.Length).EnsureTrailingSlash();
             }
         }
@@ -49,7 +49,7 @@ public static class SpecialContentPathParser {
 
         var path = url.StripTrailingSlash();
 
-        if (IsRoutable(path) && !specialPaths.Contains(path, StringComparer.OrdinalIgnoreCase)) {
+        if (IsRoutable(path) && !specialPaths.Contains(path, StringComparer.InvariantCultureIgnoreCase)) {
             specialPaths.Add(path);
         }
     }
@@ -57,7 +57,7 @@ public static class SpecialContentPathParser {
     private static IReadOnlyList<string> GetCultures(IPublishedContent specialPage) {
         return specialPage.AncestorsOrSelf()
                           .SelectMany(x => x.Cultures.Keys)
-                          .Distinct()
+                          .Distinct(StringComparer.InvariantCultureIgnoreCase)
                           .ToList();
     }
 


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

Fixes the fleet-wide 404s on campaign, crowdfunder and offering pages on culture-varying sites.

## Symptom

Every platforms route 404s on an affected site — `/donate/<campaign-slug>` and every other campaign / crowdfunder / offering URL — and stays 404 until the pod restarts. Four sites were affected; the rest were not.

## Root cause

`SpecialContentPathParser` memoised the result of `RelativeUrl()` in a process-lifetime static `Dictionary`.

`RelativeUrl()` is `Url(mode: UrlMode.Relative)` with **no culture**. When the special host page's URL varies by culture — either through its own doctype or through a **variant ancestor** — and no ambient culture resolves, Umbraco's `UrlProvider.GetUrl` ends `return url?.Text ?? "#"`. The `"#"` sentinel passes `HasValue()`, so it was cached as if it were a real path.

`ParseUri` then compared the requested path against `"#"`, never matched, returned `null`, `PlatformsContentFinder` saw `found = false`, and every platforms URL 404'd — permanently, because the failure was memoised in a static with no invalidation.

**Direct evidence:** the content finder returned in 0.09 ms with no CDN call at all, and instrumentation showed `ambient='#'` while `culture='en-us'` resolved `path='/donate'` correctly.

## What actually shipped

Nothing in the routing path. `SpecialContentPathParser` was last touched 2025-12-17 and `ContentCache` 2025-07-03. Culture variance on the host page (or an ancestor) is what made the bug *reachable*; the fleet rollout on 2026-07-31 04:55–05:32 restarted every pod, which re-cached `"#"` fresh across the estate at the same moment. That is why it looked like a deployment regression.

## The fix

- Resolve the **ambient** URL first; if routable, use it — unchanged behaviour for healthy sites.
- Otherwise fall back to `Url(culture, UrlMode.Relative)` for every culture across **`AncestorsOrSelf()`**, not just the node's own cultures. This is what covers the variant-ancestor topology.
- **Only cache routable paths** (non-empty, `/`-prefixed), so the `"#"` sentinel can never be memoised and resolution self-heals on the next request instead of needing a restart.
- `ParseUri` matches against **all** culture paths, **longest first**, so multilingual sites resolve campaigns under every culture's path.
- Comparison is `OrdinalIgnoreCase`, closing a pre-existing asymmetry where `requestedPath` was lowercased but `specialPath` was not.
- `ConcurrentDictionary` replaces a plain `Dictionary` that was being written from concurrent requests with no lock.
- Removed the separate static page cache — it could pin a node instance resolved from an incomplete snapshot, and `ContentCache` already caches that lookup.

Verified against Umbraco `release-13.14.0` sources: in `UrlMode.Relative`, `AssembleUrl` can only return a route path or `domainUri.Uri.AbsolutePath + path`, both `/`-prefixed — so `StartsWith('/')` is a sound discriminator and `"#"` is the only non-`/` value stock Umbraco produces.

## Change-by-change rationale

**Imports**

| Change | Why |
| --- | --- |
| `using System.Collections.Concurrent;` | Needed for `ConcurrentDictionary` — which we need because this static cache is read and written by many simultaneous web requests, and the plain `Dictionary` it replaced can corrupt its internal buckets or spin forever on a concurrent write. |
| `using System.Linq;` | Needed for the LINQ operators the new code uses — which we need because the fix works on a *collection* of paths now instead of a single string. |

**Field**

| Change | Why |
| --- | --- |
| Deleted `SpecialPages` dictionary | It cached the `IPublishedContent` node itself forever, so after any content refresh it handed back a stale node — and `contentCache.Special()` already caches that lookup, so it added risk for no gain. |
| `SpecialPaths` is now `ConcurrentDictionary<…>` | Thread safety, as above — this is on the hot path of every campaign request, so unsynchronised writes were a real hazard, not a theoretical one. |
| Its value is now `IReadOnlyList<string>` not `string` | A site can legitimately have more than one valid base path (one per culture), so storing a single string forced us to pick one and be wrong for every other culture. |

**`GetPath`**

| Change | Why |
| --- | --- |
| Read the ambient URL first | So healthy sites behave exactly as before — the ambient URL is the *right* answer for the current request, and we don't want the fix to change working behaviour. |
| `if (IsRoutable(ambientPath))` | **This is the bug.** `UrlProvider.GetUrl` ends `return url?.Text ?? "#"`, and `"#"` sailed through `HasValue()` — so we have to test for routability, not just non-emptiness. |
| Fall through to `GetPaths(...).FirstOrDefault()` | Because when ambient fails we still need *a* usable path; returning the sentinel or `null` is what produced the 404s and would produce a redirect-to-nowhere. |
| No early `return null` when the page is missing | A `null` here reaches `GetPageResult.ForRedirect(null, …)`, so falling through keeps a missing page from turning into a broken redirect. |

**`ParseUri`**

| Change | Why |
| --- | --- |
| Stopped calling `GetPath` | `GetPath` answers "what is the base path *for this request's culture*", but `ParseUri` needs "does the requested path match *any* of the site's base paths" — a request in culture B must still match, so one path is not enough. |
| Loop over `GetPaths(...)` | Same reason — multilingual sites have one base per culture and all of them are legitimate routes. |
| `OrderByDescending(x => x.Length)` | Because `/donate` is a prefix of `/en/donate`; without longest-first the shorter path matches, and the `Substring` then strips the wrong number of characters and produces a garbage slug. |
| `StringComparison.OrdinalIgnoreCase` | `requestedPath` is lowercased but the cached paths are not, so we need case-insensitivity — and it must be *ordinal* because a culture-sensitive compare can match a sequence of a different length, which would make the `Substring(specialPath.Length)` below silently wrong. |
| `return null` at the end instead of `else` | Same result, but it lets the loop return early on the first match rather than nesting; behaviour for "no match" is unchanged. |

**`AddPathIfRoutable`**

| Change | Why |
| --- | --- |
| New method at all | So every write into the cache passes through one gate — otherwise a future edit could add a second insertion point and reintroduce the `"#"` bug. |
| `if (!url.HasValue()) return;` | Guards `StripTrailingSlash()` against null, since `Url(culture, …)` can return null for a culture the node isn't published in. |
| `IsRoutable(path)` before adding | The whole point: nothing unroutable is allowed to be cached, ever. |
| `!specialPaths.Contains(path, …)` | On an invariant page every culture resolves to the *same* path, so without the dedupe we'd store the identical string N times and re-sort it on every request. |

**`GetCultures`**

| Change | Why |
| --- | --- |
| New method using `AncestorsOrSelf()` | Because an **invariant** page under a **variant ancestor** has no cultures of its own to iterate — Umbraco ignores the culture argument for an invariant node's own segment but still varies the ancestor's, so the cultures we need live upstream. Without this, that topology stays 404 — and one affected site runs it live. |
| `SelectMany(...).Distinct()` | Ancestors repeat the same culture keys down the tree, so we'd otherwise call `Url()` several times per culture for nothing. |
| `.ToList()` returning `IReadOnlyList<string>` | House convention is to return a materialised `IReadOnlyList<T>`; also stops the deferred query being re-enumerated inside the loop. |

**`GetPaths`**

| Change | Why |
| --- | --- |
| `TryGetValue` fast path | Resolving URLs per culture is not free, and this runs on every campaign, crowdfunder and offering request. |
| `return []` when the page is missing | Callers can then handle "nothing found" uniformly without a null check, and — critically — we *don't* write that failure into the cache. |
| `if (specialPaths.None()) return [];` | **This is what made the original bug permanent.** A failed resolution must never be memoised, so the next request can retry and the site self-heals instead of needing a pod restart. |
| `TryAdd` rather than lock-and-set | The computed value is deterministic, so if two threads race, whichever wins is equally correct — a lock would just add contention. |

**`GetRoutablePaths`**

| Change | Why |
| --- | --- |
| New method | Separates "compute the paths" from "cache them", so the caching rule in `GetPaths` stays a single readable decision. |
| Ambient path added first | It becomes index 0, which is what `GetPath`'s `FirstOrDefault()` fallback returns — so the fallback prefers the most likely-correct path rather than an arbitrary culture. |
| Then one `Url(culture, UrlMode.Relative)` per culture | `UrlMode.Relative` is required because the comparison in `ParseUri` is against a path, not an absolute URL — and relative mode provably cannot return an absolute URL. |

**`IsRoutable`**

| Change | Why |
| --- | --- |
| New method | One definition of "routable", used by both the ambient check and the cache gate, so they can't drift apart. |
| `path.HasValue() && path.StartsWith('/')` | Verified against Umbraco 13.14.0: in relative mode `AssembleUrl` can only return a `/`-prefixed value, so `"#"` is the only non-`/` string stock Umbraco produces — making this a sound and cheap discriminator that also rejects an absolute URL if some custom provider ever returned one. |

**File**

| Change | Why |
| --- | --- |
| Added trailing newline at EOF | The original file had none; POSIX tools and diffs treat a missing final newline as a change, which noises up future diffs. |

## Testing

All runs on **cold-started processes** against restored staging databases, reading the live CDN (`DevFlags.EnableLiveTesting`). The framework DLL hash was compared between the build output and each site's `bin` on every run, to prove which binary was actually loaded.

| Site | Topology | Route tested | Before | After |
| --- | --- | --- | --- | --- |
| Site A | variant `donatePage`, 1 language, no domains | `/donate/<slug>` | 404 | 200 |
| Site B | variant `donatePage`, 2 languages, path-based domains | `/en/platforms-campaigns/<slug>` | 404 | 200 |
| Site C + variance | **invariant** host page under a **variant ancestor** (`homePage` variations=1) | `/donate/<slug>` ×7 | 404 | 200 |
| Site C original | fully invariant | `/donate/<slug>` | 200 | 200 (no regression) |

Negative paths on Site C: unknown campaign slug → 302 `/donate`; unknown crowdfunder → 302 `/fundraising`; bogus extra segment → 302. No 404 anywhere — a 404 is the discriminator, since it means `ParseUri` returned `null`. Mixed case (`/Donate/<Slug>`) resolves correctly.

### Methodology note

Two early "passes" were false positives and are worth recording, because they shape what counts as evidence here:

1. **Instrumentation priming.** A diagnostic probe called `Url(culture: "en-US")` and `Cultures` *before* the ambient call, which populated Umbraco's URL cache and turned the 404 into a 200. Removing the probe restored the 404.
2. **Warm static cache.** A 200 on Site C was read as disproving the variant-ancestor hypothesis, but the process had cached the pre-variance path earlier in the session and there is no invalidation. Cold starts still 404'd — the hypothesis was correct, and `GetCultures` exists because of it.

⇒ **Only cold-start results are trustworthy for this bug.** Every number in the table above is from a fresh process.

## Deployment

A pod restart does **not** fix this — it re-caches the sentinel. Restoring the affected sites needs this framework release plus a redeploy of each.

## Follow-ups (deliberately out of scope)

- Invalidate the static cache on `IContentCache.Flushed` — a content move currently needs a restart.
- `GetPath`'s fallback picks the first path, which is provably correct on single-culture sites but arbitrary on multi-culture ones; it only surfaces via the not-found redirect.
- Add a segment-boundary guard so `/donate-now` can't prefix-match `/donate`.
- `ContentCache`'s eager `GetOrAdd(key, value)` overload evaluates its value argument unconditionally across 123 call sites.
- Malformed `urls` in `campaigns.json` for three subscriptions.
- One site's advertised campaign URL does not match its configured route base, and two of its nodes are published only in one culture.

/cc @nadrummond @talhamalik4025
