### PR TITLE
Compute the content cache value only on a miss

### DIFF
--- a/src/N3O.Umbraco.Extensions/Content/ContentCache.cs
+++ b/src/N3O.Umbraco.Extensions/Content/ContentCache.cs
@@ -22,7 +22,7 @@ public class ContentCache : IContentCache {
     public IReadOnlyList<T> All<T>(Func<T, bool> predicate = null) {
         var cacheKey = GetCacheKey<T>();
 
-        var all = (IReadOnlyList<T>) _typedStore.GetOrAdd(cacheKey, _contentLocator.All<T>());
+        var all = (IReadOnlyList<T>) _typedStore.GetOrAdd(cacheKey, _ => _contentLocator.All<T>());
         IReadOnlyList<T> res;
 
         if (predicate == null) {
@@ -42,7 +42,7 @@ public class ContentCache : IContentCache {
                                                 Func<IPublishedContent, bool> predicate = null) {
         var cacheKey = GetCacheKey(contentTypeAlias);
 
-        var all = _untypedStore.GetOrAdd(cacheKey, _contentLocator.All(contentTypeAlias));
+        var all = _untypedStore.GetOrAdd(cacheKey, _ => _contentLocator.All(contentTypeAlias));
         IReadOnlyList<IPublishedContent> res;
 
         if (predicate == null) {


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

`ContentCache` looked like a cache but paid the full cost of a cache miss on every call.

Both stores used `ConcurrentDictionary.GetOrAdd(key, value)` — the overload that takes an already-computed value rather than a factory. C# evaluates that argument before `GetOrAdd` is entered, so `_contentLocator.All<T>()` ran on every call and its result was discarded whenever the key was already present. That call walks the whole content tree from every root node (`Locator.GetAllContent`, via `GetAtRoot()` and `DescendantsOfType`), so a warm cache saved the allocation of the returned list and nothing else.

Switching both to the factory overload means the tree walk happens once per content type per flush, which is what the cache was always meant to do.

There is one behavioural consequence worth knowing. The locator resolves the ambient Umbraco context on every call today (`Locator.Run` → `GetCache(umbracoContextAccessor)`); after this change it only does so on a miss, so a warm-cache read no longer depends on an ambient context being present. That is why callers such as `ContentDonationItems.GetFromCache` currently guard with `TryGetUmbracoContext` before reading the cache. Nothing needs those guards removed — they simply stop being load-bearing.

No call site changes. The signatures of `All<T>`, `All(alias)`, `Single<T>` and `Single(alias)` are unchanged, and every consumer keeps the same result — 86 direct call sites across the solution read these members, 108 counting the `Special()` and other `IContentCache` extension helpers, and all of them get the same value for less work.

### Scope of the sweep

Every `GetOrAdd` call site in the repository was inspected: 40 in total, of which exactly the two changed here passed an eagerly-evaluated value. The rest already pass a factory (`() =>`, `url =>`, `static key =>`), including the `PropertyConverter` column-range caches, `CdnClient`, `AliasHelper`, `TypeExtensions` and `OurAssemblies`.

The same class of defect was checked for in the neighbouring APIs and none was found:

- `ConcurrentDictionary.AddOrUpdate` — `CdnClient` passes an already-computed local, `SentryEventRateLimiter` passes a factory.
- `DictionaryExtensions.GetOrAdd` / `GetOrAddOrUpdate` / `AddOrUpdate` — all declare `Func<TValue>` and are lazy by construction.
- `ConcurrentDictionaryExtensions.GetOrAddAtomic` / `GetOrAddAtomicAsync` — factory-based.
- `IMemoryCache.GetOrCreate` (`HandlebarsCompiler`) and `StagingMiddleware.FailedLogins` — factory-based.

## Test plan

- [x] Full solution builds — 0 errors, no warning references the changed file
- [x] Every `GetOrAdd` call site in the repository audited; the two changed here are the only eager ones
- [x] `Locator.Run` confirmed side-effect free beyond reading the ambient context, so deferring the call cannot change the cached value
- [ ] Deploy a site and confirm content-heavy pages render identically, with no stale or missing content after a content publish (the `Flush` path still clears both stores)
