### PR TITLE
Make culture a first-class concept with one accessor resolving it

### DIFF
--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageAccessor.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Services/Pages/PlatformsPageAccessor.cs
@@ -3,6 +3,7 @@ using N3O.Umbraco.Cloud.Platforms.Extensions;
 using N3O.Umbraco.Cloud.Platforms.Models;
 using N3O.Umbraco.Content;
 using N3O.Umbraco.ContentFinders;
+using N3O.Umbraco.Context;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Json;
 using System;
@@ -16,15 +17,18 @@ namespace N3O.Umbraco.Cloud.Platforms;
 public class PlatformsPageAccessor : IPlatformsPageAccessor {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IContentCache _contentCache;
+    private readonly ICultureAccessor _cultureAccessor;
     private readonly ICdnClient _cdnClient;
     private readonly IJsonProvider _jsonProvider;
 
     public PlatformsPageAccessor(IHttpContextAccessor httpContextAccessor,
                                  IContentCache contentCache,
+                                 ICultureAccessor cultureAccessor,
                                  ICdnClient cdnClient,
                                  IJsonProvider jsonProvider) {
         _httpContextAccessor = httpContextAccessor;
         _contentCache = contentCache;
+        _cultureAccessor = cultureAccessor;
         _cdnClient = cdnClient;
         _jsonProvider = jsonProvider;
     }
@@ -46,10 +50,14 @@ public class PlatformsPageAccessor : IPlatformsPageAccessor {
     }
     
     private async Task<GetPageResult> GetAsync(Uri requestUri, CancellationToken cancellationToken) {
+        var culture = _cultureAccessor.GetCulture();
         var fallbacks = new List<SpecialContent>();
-        
+
         foreach (var platformsPageRoute in PlatformsPageRoute.All) {
-            var platformsPath = SpecialContentPathParser.ParseUri(_contentCache, platformsPageRoute.Parent, requestUri);
+            var platformsPath = SpecialContentPathParser.ParseUri(_contentCache,
+                                                                  platformsPageRoute.Parent,
+                                                                  requestUri,
+                                                                  culture);
 
             if (!platformsPath.HasValue()) {
                 continue;
@@ -93,10 +101,12 @@ public class PlatformsPageAccessor : IPlatformsPageAccessor {
         }
         
         if (fallbacks.Any()) {
-            return GetPageResult.ForRedirect(SpecialContentPathParser.GetPath(_contentCache, fallbacks.First()),
+            return GetPageResult.ForRedirect(SpecialContentPathParser.GetPath(_contentCache,
+                                                                              fallbacks.First(),
+                                                                              culture),
                                              true);
         } else {
-            return null;   
+            return null;
         }
     }
 }

--- a/src/Giving/N3O.Umbraco.Giving.Allocations/Models/DonationForm/DonationFormMapping.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Allocations/Models/DonationForm/DonationFormMapping.cs
@@ -1,6 +1,6 @@
+using N3O.Umbraco.Context;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Giving.Allocations.Content;
-using N3O.Umbraco.Localization;
 using N3O.Umbraco.Lookups;
 using System.Linq;
 using Umbraco.Cms.Core.Mapping;
@@ -9,12 +9,14 @@ using Umbraco.Cms.Core.Models.PublishedContent;
 namespace N3O.Umbraco.Giving.Allocations.Models;
 
 public class DonationFormMapping : IMapDefinition {
+    private readonly ICultureAccessor _cultureAccessor;
     private readonly ILookups _lookups;
-    
-    public DonationFormMapping(ILookups lookups) {
+
+    public DonationFormMapping(ICultureAccessor cultureAccessor, ILookups lookups) {
+        _cultureAccessor = cultureAccessor;
         _lookups = lookups;
     }
-    
+
     public void DefineMaps(IUmbracoMapper mapper) {
         mapper.Define<DonationFormContent, DonationFormRes>((_, _) => new DonationFormRes(), Map);
     }
@@ -22,7 +24,7 @@ public class DonationFormMapping : IMapDefinition {
     // Umbraco.Code.MapAll
     private void Map(DonationFormContent src, DonationFormRes dest, MapperContext ctx) {
         dest.Title = src.Title;
-        dest.Options = src.GetOptions(_lookups, new VariationContext(LocalizationSettings.CultureCode))
+        dest.Options = src.GetOptions(_lookups, new VariationContext(_cultureAccessor.GetCulture()))
                           .OrEmpty()
                           .Select(ctx.Map<DonationOptionContent, DonationOptionRes>)
                           .ToList();

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Webhooks/CheckoutWebhookTransform.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Webhooks/CheckoutWebhookTransform.cs
@@ -1,5 +1,6 @@
 using Humanizer;
 using N3O.Umbraco.Content;
+using N3O.Umbraco.Context;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Financial;
 using N3O.Umbraco.Giving.Allocations;
@@ -26,13 +27,16 @@ public class CheckoutWebhookTransform : WebhookTransform {
         AliasHelper<PaymentMethodSettingsContent<IPaymentMethodSettings>>.PropertyAlias(x => x.RestrictCollectionDaysTo);
 
     private readonly IContentCache _contentCache;
+    private readonly ICultureAccessor _cultureAccessor;
     private readonly IPriceCalculator _priceCalculator;
 
     public CheckoutWebhookTransform(IJsonProvider jsonProvider,
                                     IContentCache contentCache,
-                                    IPriceCalculator priceCalculator) 
+                                    ICultureAccessor cultureAccessor,
+                                    IPriceCalculator priceCalculator)
         : base(jsonProvider) {
         _contentCache = contentCache;
+        _cultureAccessor = cultureAccessor;
         _priceCalculator = priceCalculator;
     }
 
@@ -111,7 +115,7 @@ public class CheckoutWebhookTransform : WebhookTransform {
     }
     
     private void TransformTags(JObject jObject) {
-        var language = LocalizationSettings.GetLanguageName(LocalizationSettings.CultureCode) ?? Site.Language;
+        var language = LocalizationSettings.GetLanguageName(_cultureAccessor.GetCulture()) ?? Site.Language;
 
         if (language.HasValue()) {
             AddTag(jObject, "SiteLanguageTag", language);

--- a/src/N3O.Umbraco.Extensions/ContentFinders/SpecialContentPathParser.cs
+++ b/src/N3O.Umbraco.Extensions/ContentFinders/SpecialContentPathParser.cs
@@ -1,98 +1,72 @@
-﻿using N3O.Umbraco.Content;
+using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
 namespace N3O.Umbraco.ContentFinders;
 
 public static class SpecialContentPathParser {
-    private static readonly ConcurrentDictionary<SpecialContent, IReadOnlyList<string>> SpecialPaths = new();
+    private static readonly ConcurrentDictionary<(SpecialContent, string), string> SpecialPaths = new();
 
     public static void Flush() {
         SpecialPaths.Clear();
     }
 
-    public static string GetPath(IContentCache contentCache, SpecialContent specialContent) {
-        var specialPage = contentCache.Special(specialContent);
+    public static string GetPath(IContentCache contentCache, SpecialContent specialContent, string culture = null) {
+        var cacheKey = GetCacheKey(specialContent, culture);
 
-        if (specialPage.HasValue()) {
-            var ambientPath = specialPage.RelativeUrl().StripTrailingSlash();
-
-            if (IsRoutable(ambientPath)) {
-                return ambientPath;
-            }
-        }
-
-        return GetPaths(contentCache, specialContent).FirstOrDefault();
-    }
-
-    public static string ParseUri(IContentCache contentCache, SpecialContent specialContent, Uri requestUri) {
-        var requestedPath = requestUri.GetAbsolutePathDecoded().ToLowerInvariant().StripTrailingSlash();
-
-        foreach (var specialPath in GetPaths(contentCache, specialContent).OrderByDescending(x => x.Length)) {
-            if (requestedPath.StartsWith(specialPath, StringComparison.InvariantCultureIgnoreCase)) {
-                return requestedPath.Substring(specialPath.Length).EnsureTrailingSlash();
-            }
-        }
-
-        return null;
-    }
-
-    private static void AddPathIfRoutable(ICollection<string> specialPaths, string url) {
-        if (!url.HasValue()) {
-            return;
-        }
-
-        var path = url.StripTrailingSlash();
-
-        if (IsRoutable(path) && !specialPaths.Contains(path, StringComparer.InvariantCultureIgnoreCase)) {
-            specialPaths.Add(path);
-        }
-    }
-
-    private static IReadOnlyList<string> GetCultures(IPublishedContent specialPage) {
-        return specialPage.AncestorsOrSelf()
-                          .SelectMany(x => x.Cultures.Keys)
-                          .Distinct(StringComparer.InvariantCultureIgnoreCase)
-                          .ToList();
-    }
-
-    private static IReadOnlyList<string> GetPaths(IContentCache contentCache, SpecialContent specialContent) {
-        if (SpecialPaths.TryGetValue(specialContent, out var cachedPaths)) {
-            return cachedPaths;
+        if (SpecialPaths.TryGetValue(cacheKey, out var cachedPath)) {
+            return cachedPath;
         }
 
         var specialPage = contentCache.Special(specialContent);
 
         if (!specialPage.HasValue()) {
-            return [];
+            return null;
         }
 
-        var specialPaths = GetRoutablePaths(specialPage);
+        var path = GetUrl(specialPage, culture).StripTrailingSlash();
 
-        if (specialPaths.None()) {
-            return [];
+        if (!IsRoutable(path)) {
+            return null;
         }
 
-        SpecialPaths.TryAdd(specialContent, specialPaths);
+        SpecialPaths.TryAdd(cacheKey, path);
 
-        return specialPaths;
+        return path;
     }
 
-    private static IReadOnlyList<string> GetRoutablePaths(IPublishedContent specialPage) {
-        var specialPaths = new List<string>();
+    public static string ParseUri(IContentCache contentCache,
+                                  SpecialContent specialContent,
+                                  Uri requestUri,
+                                  string culture = null) {
+        var specialPath = GetPath(contentCache, specialContent, culture);
 
-        AddPathIfRoutable(specialPaths, specialPage.RelativeUrl());
-
-        foreach (var culture in GetCultures(specialPage)) {
-            AddPathIfRoutable(specialPaths, specialPage.Url(culture, UrlMode.Relative));
+        if (!specialPath.HasValue()) {
+            return null;
         }
 
-        return specialPaths;
+        var requestedPath = requestUri.GetAbsolutePathDecoded().ToLowerInvariant().StripTrailingSlash();
+
+        if (requestedPath.StartsWith(specialPath, StringComparison.InvariantCultureIgnoreCase)) {
+            return requestedPath.Substring(specialPath.Length).EnsureTrailingSlash();
+        }
+
+        return null;
+    }
+
+    private static (SpecialContent, string) GetCacheKey(SpecialContent specialContent, string culture) {
+        return (specialContent, culture?.ToLowerInvariant());
+    }
+
+    private static string GetUrl(IPublishedContent specialPage, string culture) {
+        if (culture.HasValue()) {
+            return specialPage.Url(culture, UrlMode.Relative);
+        }
+
+        return specialPage.RelativeUrl();
     }
 
     private static bool IsRoutable(string path) {

--- a/src/N3O.Umbraco.Extensions/ContentFinders/SpecialContentPathParser.cs
+++ b/src/N3O.Umbraco.Extensions/ContentFinders/SpecialContentPathParser.cs
@@ -1,4 +1,4 @@
-using N3O.Umbraco.Content;
+﻿using N3O.Umbraco.Content;
 using N3O.Umbraco.Extensions;
 using System;
 using System.Collections.Concurrent;
@@ -17,7 +17,8 @@ public static class SpecialContentPathParser {
     public static string GetPath(IContentCache contentCache, SpecialContent specialContent, string culture = null) {
         var cacheKey = GetCacheKey(specialContent, culture);
 
-        if (SpecialPaths.TryGetValue(cacheKey, out var cachedPath)) {
+        // An ambient resolution varies with the caller's context, so only an explicit culture's path is cached.
+        if (culture.HasValue() && SpecialPaths.TryGetValue(cacheKey, out var cachedPath)) {
             return cachedPath;
         }
 
@@ -33,7 +34,9 @@ public static class SpecialContentPathParser {
             return null;
         }
 
-        SpecialPaths.TryAdd(cacheKey, path);
+        if (culture.HasValue()) {
+            SpecialPaths.TryAdd(cacheKey, path);
+        }
 
         return path;
     }

--- a/src/N3O.Umbraco.Extensions/Context/Accessors/CultureAccessor.I.cs
+++ b/src/N3O.Umbraco.Extensions/Context/Accessors/CultureAccessor.I.cs
@@ -1,0 +1,5 @@
+namespace N3O.Umbraco.Context;
+
+public interface ICultureAccessor {
+    string GetCulture(string culture = null);
+}

--- a/src/N3O.Umbraco.Extensions/Context/Accessors/CultureAccessor.cs
+++ b/src/N3O.Umbraco.Extensions/Context/Accessors/CultureAccessor.cs
@@ -1,0 +1,102 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Localization;
+using N3O.Umbraco.Extensions;
+using System;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
+
+namespace N3O.Umbraco.Context;
+
+public class CultureAccessor : ICultureAccessor {
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IUmbracoContextAccessor _umbracoContextAccessor;
+    private readonly IVariationContextAccessor _variationContextAccessor;
+    private readonly IDefaultCultureAccessor _defaultCultureAccessor;
+
+    public CultureAccessor(IHttpContextAccessor httpContextAccessor,
+                           IUmbracoContextAccessor umbracoContextAccessor,
+                           IVariationContextAccessor variationContextAccessor,
+                           IDefaultCultureAccessor defaultCultureAccessor) {
+        _httpContextAccessor = httpContextAccessor;
+        _umbracoContextAccessor = umbracoContextAccessor;
+        _variationContextAccessor = variationContextAccessor;
+        _defaultCultureAccessor = defaultCultureAccessor;
+    }
+
+    public string GetCulture(string culture = null) {
+        if (culture.HasValue()) {
+            return culture;
+        }
+
+        var routedCulture = GetRoutedCulture();
+
+        if (routedCulture.HasValue()) {
+            return routedCulture;
+        }
+
+        var requestCulture = GetRequestCulture();
+
+        if (requestCulture.HasValue()) {
+            return requestCulture;
+        }
+
+        var domainCulture = GetDomainCulture();
+
+        if (domainCulture.HasValue()) {
+            return domainCulture;
+        }
+
+        var variationCulture = GetVariationCulture();
+
+        if (variationCulture.HasValue()) {
+            return variationCulture;
+        }
+
+        return _defaultCultureAccessor.DefaultCulture;
+    }
+
+    private string GetDomainCulture() {
+        if (!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext) ||
+            umbracoContext.Domains == null) {
+            return null;
+        }
+
+        var requestUri = GetRequestUri();
+
+        if (requestUri == null) {
+            return null;
+        }
+
+        var domains = umbracoContext.Domains.GetAll(false);
+        var domainAndUri = DomainUtilities.SelectDomain(domains,
+                                                        requestUri,
+                                                        defaultCulture: umbracoContext.Domains.DefaultCulture);
+
+        return domainAndUri?.Culture;
+    }
+
+    private string GetRequestCulture() {
+        var requestCulture = _httpContextAccessor.HttpContext?.Features.Get<IRequestCultureFeature>();
+
+        return requestCulture?.RequestCulture.Culture.Name;
+    }
+
+    private Uri GetRequestUri() {
+        return _httpContextAccessor.HttpContext?.Request.Uri();
+    }
+
+    private string GetRoutedCulture() {
+        if (!_umbracoContextAccessor.TryGetUmbracoContext(out var umbracoContext)) {
+            return null;
+        }
+
+        return umbracoContext.PublishedRequest?.Culture;
+    }
+
+    private string GetVariationCulture() {
+        return _variationContextAccessor.VariationContext?.Culture;
+    }
+}

--- a/src/N3O.Umbraco.Extensions/Context/Accessors/CultureAccessor.cs
+++ b/src/N3O.Umbraco.Extensions/Context/Accessors/CultureAccessor.cs
@@ -15,15 +15,18 @@ public class CultureAccessor : ICultureAccessor {
     private readonly IUmbracoContextAccessor _umbracoContextAccessor;
     private readonly IVariationContextAccessor _variationContextAccessor;
     private readonly IDefaultCultureAccessor _defaultCultureAccessor;
+    private readonly UmbracoRequestPaths _umbracoRequestPaths;
 
     public CultureAccessor(IHttpContextAccessor httpContextAccessor,
                            IUmbracoContextAccessor umbracoContextAccessor,
                            IVariationContextAccessor variationContextAccessor,
-                           IDefaultCultureAccessor defaultCultureAccessor) {
+                           IDefaultCultureAccessor defaultCultureAccessor,
+                           UmbracoRequestPaths umbracoRequestPaths) {
         _httpContextAccessor = httpContextAccessor;
         _umbracoContextAccessor = umbracoContextAccessor;
         _variationContextAccessor = variationContextAccessor;
         _defaultCultureAccessor = defaultCultureAccessor;
+        _umbracoRequestPaths = umbracoRequestPaths;
     }
 
     public string GetCulture(string culture = null) {
@@ -31,22 +34,25 @@ public class CultureAccessor : ICultureAccessor {
             return culture;
         }
 
-        var routedCulture = GetRoutedCulture();
+        // The request-localization and domain signals describe the staff member on backoffice requests.
+        if (!IsBackOfficeRequest()) {
+            var routedCulture = GetRoutedCulture();
 
-        if (routedCulture.HasValue()) {
-            return routedCulture;
-        }
+            if (routedCulture.HasValue()) {
+                return routedCulture;
+            }
 
-        var requestCulture = GetRequestCulture();
+            var requestCulture = GetRequestCulture();
 
-        if (requestCulture.HasValue()) {
-            return requestCulture;
-        }
+            if (requestCulture.HasValue()) {
+                return requestCulture;
+            }
 
-        var domainCulture = GetDomainCulture();
+            var domainCulture = GetDomainCulture();
 
-        if (domainCulture.HasValue()) {
-            return domainCulture;
+            if (domainCulture.HasValue()) {
+                return domainCulture;
+            }
         }
 
         var variationCulture = GetVariationCulture();
@@ -98,5 +104,15 @@ public class CultureAccessor : ICultureAccessor {
 
     private string GetVariationCulture() {
         return _variationContextAccessor.VariationContext?.Culture;
+    }
+
+    private bool IsBackOfficeRequest() {
+        var httpContext = _httpContextAccessor.HttpContext;
+
+        if (httpContext == null) {
+            return false;
+        }
+
+        return _umbracoRequestPaths.IsBackOfficeRequest(httpContext.Request.Path.ToString());
     }
 }

--- a/src/N3O.Umbraco.Extensions/Context/ContextComposer.cs
+++ b/src/N3O.Umbraco.Extensions/Context/ContextComposer.cs
@@ -11,6 +11,7 @@ public class ContextComposer : Composer {
     public override void Compose(IUmbracoBuilder builder) {
         builder.Services.AddSingleton<IBaseCurrencyAccessor, BaseCurrencyAccessor>();
         builder.Services.AddSingleton<IBrowserInfoAccessor, BrowserInfoAccessor>();
+        builder.Services.AddSingleton<ICultureAccessor, CultureAccessor>();
         builder.Services.AddScoped<ICurrencyAccessor, CurrencyAccessor>();
         builder.Services.AddScoped<ICurrencyCodeAccessor, CurrencyCodeAccessor>();
         builder.Services.AddScoped<IDefaultCurrencyProvider, LookupsDefaultCurrencyProvider>();

--- a/src/N3O.Umbraco.Extensions/Extensions/UrlBuilderExtensions.cs
+++ b/src/N3O.Umbraco.Extensions/Extensions/UrlBuilderExtensions.cs
@@ -9,9 +9,10 @@ namespace N3O.Umbraco.Extensions;
 public static class UrlBuilderExtensions {
     public static Url SpecialPage(this UrlBuilder urlBuilder,
                                   IContentCache contentCache,
-                                  SpecialContent specialContent) {
+                                  SpecialContent specialContent,
+                                  string culture = null) {
         var url = urlBuilder.Root();
-        var path = SpecialContentPathParser.GetPath(contentCache, specialContent);
+        var path = SpecialContentPathParser.GetPath(contentCache, specialContent, culture);
 
         if (!path.HasValue()) {
             throw new Exception($"Could not resolve path for {specialContent.Id.Quote()}");

--- a/src/N3O.Umbraco.Extensions/Localization/LocalizationSettings.cs
+++ b/src/N3O.Umbraco.Extensions/Localization/LocalizationSettings.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 
 namespace N3O.Umbraco.Localization;
 
@@ -26,8 +25,6 @@ public class LocalizationSettings : Value {
     public DateFormat DateFormat { get; }
     public TimeFormat TimeFormat { get; }
     public Timezone Timezone { get; }
-    
-    public static string CultureCode => Thread.CurrentThread.CurrentCulture.ToString();
 
     public static string GetLanguageName(string cultureCode) {
         try {

--- a/src/N3O.Umbraco.Extensions/Localization/Text/StringLocalizer.Content.cs
+++ b/src/N3O.Umbraco.Extensions/Localization/Text/StringLocalizer.Content.cs
@@ -1,6 +1,7 @@
 using AsyncKeyedLock;
 using Humanizer;
 using N3O.Umbraco.Content;
+using N3O.Umbraco.Context;
 using N3O.Umbraco.Dev;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Utilities;
@@ -17,17 +18,19 @@ public abstract class ContentStringLocalizer : IStringLocalizer {
     protected static readonly string TextContainerAlias = AliasHelper<TextContainerContent>.ContentTypeAlias();
     protected static readonly string TextContainerFolderAlias = AliasHelper<TextContainerFolderContent>.ContentTypeAlias();
     private static readonly string TextSettingsContentAlias = AliasHelper<TextSettingsContent>.ContentTypeAlias();
-    
+
     private readonly ConcurrentDictionary<string, string> _stringCache = new();
     private readonly ILocalizationSettingsAccessor _localizationSettingsAccessor;
     private IPublishedContent _textSettingsContent;
 
     protected ContentStringLocalizer(IContentCache contentCache,
+                                     ICultureAccessor cultureAccessor,
                                      ILocalizationSettingsAccessor localizationSettingsAccessor,
                                      AsyncKeyedLocker<string> locker) {
         _localizationSettingsAccessor = localizationSettingsAccessor;
 
         ContentCache = contentCache;
+        CultureAccessor = cultureAccessor;
         Locker = locker;
     }
 
@@ -44,7 +47,7 @@ public abstract class ContentStringLocalizer : IStringLocalizer {
             return text;
         }
 
-        if (!_localizationSettingsAccessor.GetSettings().AllCultureCodes.Contains(LocalizationSettings.CultureCode)) {
+        if (!_localizationSettingsAccessor.GetSettings().AllCultureCodes.Contains(CultureAccessor.GetCulture())) {
             return text;
         }
         
@@ -64,7 +67,7 @@ public abstract class ContentStringLocalizer : IStringLocalizer {
     protected abstract string GetText(string folderName, string name, string text);
 
     private string GetCacheKey(params object[] values) {
-        var newValues = values.OrEmpty().Concat(LocalizationSettings.CultureCode).ToArray();
+        var newValues = values.OrEmpty().Concat(CultureAccessor.GetCulture()).ToArray();
 
         return CacheKey.Generate<ContentStringLocalizer>(newValues);
     }
@@ -92,5 +95,6 @@ public abstract class ContentStringLocalizer : IStringLocalizer {
     }
 
     protected IContentCache ContentCache { get; }
+    protected ICultureAccessor CultureAccessor { get; }
     protected AsyncKeyedLocker<string> Locker { get; }
 }

--- a/src/N3O.Umbraco.Extensions/Localization/Text/StringLocalizer.ReadOnly.cs
+++ b/src/N3O.Umbraco.Extensions/Localization/Text/StringLocalizer.ReadOnly.cs
@@ -10,9 +10,9 @@ using Umbraco.Extensions;
 namespace N3O.Umbraco.Localization;
 
 public class ReadOnlyStringLocalizer : ContentStringLocalizer {
-    public ReadOnlyStringLocalizer(ICultureAccessor cultureAccessor,
+    public ReadOnlyStringLocalizer(IContentCache contentCache,
+                                   ICultureAccessor cultureAccessor,
                                    ILocalizationSettingsAccessor localizationSettingsAccessor,
-                                   IContentCache contentCache,
                                    AsyncKeyedLocker<string> locker)
         : base(contentCache, cultureAccessor, localizationSettingsAccessor, locker) { }
 

--- a/src/N3O.Umbraco.Extensions/Localization/Text/StringLocalizer.ReadOnly.cs
+++ b/src/N3O.Umbraco.Extensions/Localization/Text/StringLocalizer.ReadOnly.cs
@@ -1,5 +1,6 @@
 using AsyncKeyedLock;
 using N3O.Umbraco.Content;
+using N3O.Umbraco.Context;
 using N3O.Umbraco.Extensions;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,10 +10,11 @@ using Umbraco.Extensions;
 namespace N3O.Umbraco.Localization;
 
 public class ReadOnlyStringLocalizer : ContentStringLocalizer {
-    public ReadOnlyStringLocalizer(ILocalizationSettingsAccessor localizationSettingsAccessor,
+    public ReadOnlyStringLocalizer(ICultureAccessor cultureAccessor,
+                                   ILocalizationSettingsAccessor localizationSettingsAccessor,
                                    IContentCache contentCache,
                                    AsyncKeyedLocker<string> locker)
-        : base(contentCache, localizationSettingsAccessor, locker) { }
+        : base(contentCache, cultureAccessor, localizationSettingsAccessor, locker) { }
 
     protected override string GetText(string folderName, string name, string text) {
         var folder = GetFolder(folderName);
@@ -61,5 +63,5 @@ public class ReadOnlyStringLocalizer : ContentStringLocalizer {
         return textContainerContent.OrEmpty(x => x.Resources);
     }
     
-    private VariationContext VariationContext => new (LocalizationSettings.CultureCode);
+    private VariationContext VariationContext => new (CultureAccessor.GetCulture());
 }

--- a/src/N3O.Umbraco.Extensions/Localization/Text/StringLocalizer.ReadWrite.cs
+++ b/src/N3O.Umbraco.Extensions/Localization/Text/StringLocalizer.ReadWrite.cs
@@ -23,9 +23,9 @@ public class ReadWriteStringLocalizer : ContentStringLocalizer {
     private readonly ConcurrentDictionary<string, int> _cache = new();
     private string _defaultCultureCode;
     
-    public ReadWriteStringLocalizer(ICultureAccessor cultureAccessor,
+    public ReadWriteStringLocalizer(IContentCache contentCache,
+                                    ICultureAccessor cultureAccessor,
                                     ILocalizationSettingsAccessor localizationSettingsAccessor,
-                                    IContentCache contentCache,
                                     IContentService contentService,
                                     IContentTypeService contentTypeService,
                                     ICoreScopeProvider coreScopeProvider,

--- a/src/N3O.Umbraco.Extensions/Localization/Text/StringLocalizer.ReadWrite.cs
+++ b/src/N3O.Umbraco.Extensions/Localization/Text/StringLocalizer.ReadWrite.cs
@@ -1,5 +1,6 @@
 using AsyncKeyedLock;
 using N3O.Umbraco.Content;
+using N3O.Umbraco.Context;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Utilities;
 using Newtonsoft.Json;
@@ -22,13 +23,14 @@ public class ReadWriteStringLocalizer : ContentStringLocalizer {
     private readonly ConcurrentDictionary<string, int> _cache = new();
     private string _defaultCultureCode;
     
-    public ReadWriteStringLocalizer(ILocalizationSettingsAccessor localizationSettingsAccessor,
+    public ReadWriteStringLocalizer(ICultureAccessor cultureAccessor,
+                                    ILocalizationSettingsAccessor localizationSettingsAccessor,
                                     IContentCache contentCache,
                                     IContentService contentService,
                                     IContentTypeService contentTypeService,
                                     ICoreScopeProvider coreScopeProvider,
                                     AsyncKeyedLocker<string> locker)
-        : base(contentCache, localizationSettingsAccessor, locker) {
+        : base(contentCache, cultureAccessor, localizationSettingsAccessor, locker) {
         _localizationSettingsAccessor = localizationSettingsAccessor;
         _contentService = contentService;
         _contentTypeService = contentTypeService;
@@ -143,7 +145,7 @@ public class ReadWriteStringLocalizer : ContentStringLocalizer {
                 }
             }
 
-            var culture = containerContent.ContentType.VariesByCulture() ? LocalizationSettings.CultureCode : null;
+            var culture = containerContent.ContentType.VariesByCulture() ? CultureAccessor.GetCulture() : null;
 
             var resources = GetTextResources(containerContent, culture);
 

--- a/src/Scheduler/N3O.Umbraco.Scheduler/Services/BackgroundJob.cs
+++ b/src/Scheduler/N3O.Umbraco.Scheduler/Services/BackgroundJob.cs
@@ -1,6 +1,6 @@
+using N3O.Umbraco.Context;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Json;
-using N3O.Umbraco.Localization;
 using N3O.Umbraco.Mediator;
 using N3O.Umbraco.Parameters;
 using N3O.Umbraco.Scheduler.Attributes;
@@ -13,13 +13,16 @@ public class BackgroundJob : IBackgroundJob {
     private readonly IFluentParametersBuilder _fluentParametersBuilder;
     private readonly IJsonProvider _jsonProvider;
     private readonly IClock _clock;
+    private readonly ICultureAccessor _cultureAccessor;
 
     public BackgroundJob(IFluentParametersBuilder fluentParametersBuilder,
                          IJsonProvider jsonProvider,
-                         IClock clock) {
+                         IClock clock,
+                         ICultureAccessor cultureAccessor) {
         _fluentParametersBuilder = fluentParametersBuilder;
         _jsonProvider = jsonProvider;
         _clock = clock;
+        _cultureAccessor = cultureAccessor;
     }
 
     public string Enqueue<TRequest, TModel>(string jobName,
@@ -48,7 +51,7 @@ public class BackgroundJob : IBackgroundJob {
 
         addParameters?.Invoke(_fluentParametersBuilder);
 
-        _fluentParametersBuilder.Add(SchedulerConstants.Parameters.Culture, LocalizationSettings.CultureCode);
+        _fluentParametersBuilder.Add(SchedulerConstants.Parameters.Culture, _cultureAccessor.GetCulture());
 
         var parameterData = _fluentParametersBuilder.Build().ToDictionary();
 


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

There was no single place that answered "what culture is this request in?". Different code read different ambient sources — the thread culture (set by ASP.NET's request localization, second-to-last in the pipeline), Umbraco's `VariationContext` (which on front-end requests is just the site default), or Umbraco's routed culture — and they agree most of the time by coincidence. During URL routing, before the late mechanisms have run, *nothing* had an answer: code that asked anyway received Umbraco's `"#"` failure sentinel, and memoising that is what produced the fleet-wide platforms 404s. #919 fixed the caching side of that incident; this PR fixes the culture side and replaces #919's compensation layer with the real design.

### The design

Culture becomes a **first-class, nullable parameter**, exactly as Umbraco's own APIs model it: multi-culture code passes it, single-culture sites ignore it and get the right default. The default comes from one new component, `ICultureAccessor` in `Context/Accessors/` (alongside the existing per-request accessors), which resolves in a fixed order:

1. the explicit argument, when given
2. `PublishedRequest.Culture` — the routed content culture
3. `IRequestCultureFeature` — the request-localization culture, which is how API calls state their culture via `Accept-Language`
4. `DomainUtilities.SelectDomain` over the request URI with `IDomainCache.DefaultCulture` — the same rule Umbraco's `FindDomain` applies, used **only** for the pre-routing window (content finders and pre-pipeline middleware), which is the window the 404 incident lived in; this is the single place Umbraco routing internals appear
5. `VariationContext.Culture`
6. `IDefaultCultureAccessor.DefaultCulture`

Rungs are evaluated lazily in that order; the first with a value wins. On **backoffice requests** rungs 2–4 are skipped: there the request-localization culture is the staff member's UI language and the domain describes nothing, while the `VariationContext` carries the culture the backoffice (or preview code) deliberately established — so backoffice resolution is explicit argument → `VariationContext` → default, which preserves block-preview localization for staff whose UI language differs from the site's culture.

### What changed

- **`SpecialContentPathParser`** takes `string culture = null` on `GetPath`/`ParseUri`, resolves `Url(culture, UrlMode.Relative)` when supplied, and caches per `(SpecialContent, culture)` — but only for an **explicit** culture, since an ambient resolution varies with the caller's context and memoising it would freeze the first caller's culture for everyone. The parser stays culture-dumb — it receives a culture, never resolves one. The routable-only cache gate and flush invalidation from #919 remain.
- **The #919 compensation layer is deleted** — `GetCultures`, `GetRoutablePaths`, `AddPathIfRoutable`, the `AncestorsOrSelf()` enumeration, longest-first matching and the arbitrary `FirstOrDefault()` fallback. It existed only because callers did not know the culture; now they do. This also closes the two coverage gaps review found in it: sites without domains could only ever resolve the default language's path, and cultures existing solely as domain assignments were never enumerated.
- **`PlatformsPageAccessor`** resolves the culture once per request through the accessor and passes it down — this is what makes the pre-pipeline CDN middleware call correct, via rung 4.
- **`UrlBuilderExtensions.SpecialPage`** gains the optional culture parameter.
- **Every consumer of the ambient thread culture migrates to the accessor**: `ContentStringLocalizer` and both subclasses, `DonationFormMapping`, `CheckoutWebhookTransform`, and the scheduler's `BackgroundJob` (jobs are stamped with the resolved culture at schedule time). Behaviour is identical on API requests — rung 3 is what those consumers effectively read today — and newly correct during routing, where the thread culture does not yet exist.

### Breaking change, by design

**`LocalizationSettings.CultureCode` is deleted.** It was a static property on a settings class that read ambient thread state — it looked like configuration and behaved like per-request state, which is precisely why it kept being treated as a safe universal answer. There is no shim and no obsoletion period: consuming sites will get compile errors on upgrade, and each error is a call site that should be pointing at `ICultureAccessor` (or receiving a culture explicitly). Site layouts that rendered it into page markup should switch to `@inject ICultureAccessor` — and stamping the *routed* culture there, rather than the browser-preference culture, is the follow-up that makes multilingual API calls carry the culture of the page the visitor is actually on.

## Test plan

- [x] Full solution builds — 0 errors, no warnings in any touched file
- [x] Zero references to `LocalizationSettings.CultureCode` remain (grep-verified)
- [x] Every rung of the accessor verified against the pinned Umbraco 13.14.0 binaries (`SelectDomain` signature, `IDomainCache.DefaultCulture`, `PublishedRequest.Culture`, `VariationContext` semantics), and `SelectDomain` confirmed signature-identical in 18.0.2
- [x] Middleware ordering verified from decompiled 13.14.0 source: `RunPrePipeline()` runs before `UmbracoRequestMiddleware` and `UseRequestLocalization`, so rung 4 is reachable exactly when rungs 2–3 are not
- [ ] Cold-start matrix on restored staging databases, as for #919: single-language variant site, multilingual path-domain site, invariant page under variant ancestor, fully invariant site — campaign/crowdfunder/offering routes 200, negative paths 302, no 404s
- [ ] On the multilingual topology, request each culture's path cold and confirm the resolved culture (and therefore the matched base path) follows the URL, not the browser `Accept-Language`
- [ ] Complete a checkout on a staging site and confirm the webhook's language tag and the scheduled job's culture stamp are unchanged
- [ ] After upgrading a consuming site: fix the compile errors the deletion surfaces by pointing each at the accessor
