### PR TITLE
Carry the donor's culture on the checkout entity so the webhook language tag is correct

### DIFF
--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Controllers/CheckoutPageController.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Controllers/CheckoutPageController.cs
@@ -50,7 +50,8 @@ public class CheckoutPageController : PageController {
         if (_queryStringAccessor.Has("framed")) {
             return CurrentTemplate(new ContentModel(CurrentPage));
         } else {
-            var checkout = await _checkoutAccessor.GetOrCreateAsync(cancellationToken, true);
+            var checkout = await _checkoutAccessor.GetOrCreateAsync(refreshCulture: true,
+                                                                   cancellationToken: cancellationToken);
 
             string url;
 

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Controllers/CheckoutPageController.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Controllers/CheckoutPageController.cs
@@ -50,7 +50,7 @@ public class CheckoutPageController : PageController {
         if (_queryStringAccessor.Has("framed")) {
             return CurrentTemplate(new ContentModel(CurrentPage));
         } else {
-            var checkout = await _checkoutAccessor.GetOrCreateAsync(cancellationToken);
+            var checkout = await _checkoutAccessor.GetOrCreateAsync(cancellationToken, true);
 
             string url;
 

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Controllers/CheckoutStagePageController.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Controllers/CheckoutStagePageController.cs
@@ -47,7 +47,7 @@ public abstract class CheckoutStagePageController : PageController {
     }
 
     public override async Task<IActionResult> Index(CancellationToken cancellationToken) {
-        var checkout = await _checkoutAccessor.GetOrCreateAsync(CancellationToken.None);
+        var checkout = await _checkoutAccessor.GetOrCreateAsync(CancellationToken.None, true);
 
         string redirectUrl = null;
 

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Controllers/CheckoutStagePageController.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Controllers/CheckoutStagePageController.cs
@@ -47,7 +47,7 @@ public abstract class CheckoutStagePageController : PageController {
     }
 
     public override async Task<IActionResult> Index(CancellationToken cancellationToken) {
-        var checkout = await _checkoutAccessor.GetOrCreateAsync(CancellationToken.None, true);
+        var checkout = await _checkoutAccessor.GetOrCreateAsync(refreshCulture: true);
 
         string redirectUrl = null;
 

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.Create.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.Create.cs
@@ -12,6 +12,7 @@ namespace N3O.Umbraco.Giving.Checkout.Entities;
 
 public partial class Checkout {
     public static async Task<Checkout> CreateAsync(ICounters counters,
+                                                   ICultureAccessor cultureAccessor,
                                                    ILookups lookups,
                                                    IRemoteIpAddressAccessor remoteIpAddressAccessor,
                                                    EntityId id,
@@ -20,6 +21,7 @@ public partial class Checkout {
 
         checkout.CartRevisionId = cart.RevisionId;
         checkout.Reference = await counters.NextAsync<CheckoutReferenceType>();
+        checkout.Culture = cultureAccessor.GetCulture();
         checkout.Currency = cart.Currency;
         checkout.Donation = new DonationCheckout(cart.Donation.Allocations, cart.Currency);
         checkout.RegularGiving = new RegularGivingCheckout(cart.RegularGiving.Allocations, cart.Currency);

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.UpdateCulture.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.UpdateCulture.cs
@@ -1,0 +1,9 @@
+using N3O.Umbraco.Context;
+
+namespace N3O.Umbraco.Giving.Checkout.Entities;
+
+public partial class Checkout {
+    public void UpdateCulture(ICultureAccessor cultureAccessor) {
+        Culture = cultureAccessor.GetCulture();
+    }
+}

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Entities/Checkout.cs
@@ -18,6 +18,7 @@ public partial class Checkout : Entity, IPaymentsFlow {
     public RegularGivingCheckout RegularGiving { get; private set; }
     public IPAddress RemoteIp { get; private set; }
     public object Attribution { get; private set; }
+    public string Culture { get; private set; }
 
     public bool IsComplete => Progress.RequiredStages.All(x => x.IsComplete(this));
 }

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Handlers/GetOrBeginCheckoutHandler.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Handlers/GetOrBeginCheckoutHandler.cs
@@ -18,7 +18,7 @@ public class GetOrBeginCheckoutHandler : IRequestHandler<GetOrBeginCheckoutComma
     }
     
     public async Task<CheckoutRes> Handle(GetOrBeginCheckoutCommand req, CancellationToken cancellationToken) {
-        var checkout = await _checkoutAccessor.GetOrCreateAsync(cancellationToken);
+        var checkout = await _checkoutAccessor.GetOrCreateAsync(cancellationToken: cancellationToken);
         
         var res = checkout.IfNotNull(_mapper.Map<Entities.Checkout, CheckoutRes>);
 

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Services/CheckoutAccessor.I.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Services/CheckoutAccessor.I.cs
@@ -6,5 +6,5 @@ namespace N3O.Umbraco.Giving.Checkout;
 public interface ICheckoutAccessor {
     Entities.Checkout Get();
     Task<Entities.Checkout> GetAsync(CancellationToken cancellationToken = default);
-    Task<Entities.Checkout> GetOrCreateAsync(CancellationToken cancellationToken);
+    Task<Entities.Checkout> GetOrCreateAsync(CancellationToken cancellationToken, bool refreshCulture = false);
 }

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Services/CheckoutAccessor.I.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Services/CheckoutAccessor.I.cs
@@ -6,5 +6,6 @@ namespace N3O.Umbraco.Giving.Checkout;
 public interface ICheckoutAccessor {
     Entities.Checkout Get();
     Task<Entities.Checkout> GetAsync(CancellationToken cancellationToken = default);
-    Task<Entities.Checkout> GetOrCreateAsync(CancellationToken cancellationToken, bool refreshCulture = false);
+    Task<Entities.Checkout> GetOrCreateAsync(bool refreshCulture = false,
+                                             CancellationToken cancellationToken = default);
 }

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Services/CheckoutAccessor.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Services/CheckoutAccessor.cs
@@ -51,8 +51,8 @@ public class CheckoutAccessor : ICheckoutAccessor {
         return checkout;
     }
     
-    public async Task<Entities.Checkout> GetOrCreateAsync(CancellationToken cancellationToken,
-                                                          bool refreshCulture = false) {
+    public async Task<Entities.Checkout> GetOrCreateAsync(bool refreshCulture = false,
+                                                          CancellationToken cancellationToken = default) {
         var checkoutId = _checkoutIdAccessor.GetId();
         
         using (await _locker.LockAsync(checkoutId.ToString(), cancellationToken)) {
@@ -71,7 +71,9 @@ public class CheckoutAccessor : ICheckoutAccessor {
 
                     await _repository.InsertAsync(checkout);
                 }
-            } else if (refreshCulture && !_cultureAccessor.GetCulture().EqualsInvariant(checkout.Culture)) {
+            } else if (refreshCulture &&
+                       !checkout.IsComplete &&
+                       !_cultureAccessor.GetCulture().EqualsInvariant(checkout.Culture)) {
                 checkout.UpdateCulture(_cultureAccessor);
 
                 await _repository.UpdateAsync(checkout, RevisionBehaviour.Unchanged);

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Services/CheckoutAccessor.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Services/CheckoutAccessor.cs
@@ -1,6 +1,7 @@
 using AsyncKeyedLock;
 using N3O.Umbraco.Context;
 using N3O.Umbraco.Entities;
+using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Giving.Cart;
 using N3O.Umbraco.Lookups;
 using N3O.Umbraco.References;
@@ -12,6 +13,7 @@ namespace N3O.Umbraco.Giving.Checkout;
 
 public class CheckoutAccessor : ICheckoutAccessor {
     private readonly ICheckoutIdAccessor _checkoutIdAccessor;
+    private readonly ICultureAccessor _cultureAccessor;
     private readonly AsyncKeyedLocker<string> _locker;
     private readonly IRepository<Entities.Checkout> _repository;
     private readonly Lazy<ICartAccessor> _cartAccessor;
@@ -20,6 +22,7 @@ public class CheckoutAccessor : ICheckoutAccessor {
     private readonly Lazy<IRemoteIpAddressAccessor> _remoteIpAddressAccessor;
 
     public CheckoutAccessor(ICheckoutIdAccessor checkoutIdAccessor,
+                            ICultureAccessor cultureAccessor,
                             AsyncKeyedLocker<string> locker,
                             IRepository<Entities.Checkout> repository,
                             Lazy<ICartAccessor> cartAccessor,
@@ -27,6 +30,7 @@ public class CheckoutAccessor : ICheckoutAccessor {
                             Lazy<ILookups> lookups,
                             Lazy<IRemoteIpAddressAccessor> remoteIpAddressAccessor) {
         _checkoutIdAccessor = checkoutIdAccessor;
+        _cultureAccessor = cultureAccessor;
         _locker = locker;
         _repository = repository;
         _cartAccessor = cartAccessor;
@@ -47,7 +51,8 @@ public class CheckoutAccessor : ICheckoutAccessor {
         return checkout;
     }
     
-    public async Task<Entities.Checkout> GetOrCreateAsync(CancellationToken cancellationToken) {
+    public async Task<Entities.Checkout> GetOrCreateAsync(CancellationToken cancellationToken,
+                                                          bool refreshCulture = false) {
         var checkoutId = _checkoutIdAccessor.GetId();
         
         using (await _locker.LockAsync(checkoutId.ToString(), cancellationToken)) {
@@ -58,6 +63,7 @@ public class CheckoutAccessor : ICheckoutAccessor {
 
                 if (!cart.IsEmpty()) {
                     checkout = await Entities.Checkout.CreateAsync(_counters.Value,
+                                                                   _cultureAccessor,
                                                                    _lookups.Value,
                                                                    _remoteIpAddressAccessor.Value,
                                                                    checkoutId,
@@ -65,6 +71,10 @@ public class CheckoutAccessor : ICheckoutAccessor {
 
                     await _repository.InsertAsync(checkout);
                 }
+            } else if (refreshCulture && !_cultureAccessor.GetCulture().EqualsInvariant(checkout.Culture)) {
+                checkout.UpdateCulture(_cultureAccessor);
+
+                await _repository.UpdateAsync(checkout, RevisionBehaviour.Unchanged);
             }
 
             return checkout;

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Webhooks/CheckoutWebhookTransform.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Webhooks/CheckoutWebhookTransform.cs
@@ -1,6 +1,5 @@
 using Humanizer;
 using N3O.Umbraco.Content;
-using N3O.Umbraco.Context;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Financial;
 using N3O.Umbraco.Giving.Allocations;
@@ -27,16 +26,13 @@ public class CheckoutWebhookTransform : WebhookTransform {
         AliasHelper<PaymentMethodSettingsContent<IPaymentMethodSettings>>.PropertyAlias(x => x.RestrictCollectionDaysTo);
 
     private readonly IContentCache _contentCache;
-    private readonly ICultureAccessor _cultureAccessor;
     private readonly IPriceCalculator _priceCalculator;
 
     public CheckoutWebhookTransform(IJsonProvider jsonProvider,
                                     IContentCache contentCache,
-                                    ICultureAccessor cultureAccessor,
                                     IPriceCalculator priceCalculator)
         : base(jsonProvider) {
         _contentCache = contentCache;
-        _cultureAccessor = cultureAccessor;
         _priceCalculator = priceCalculator;
     }
 
@@ -54,7 +50,7 @@ public class CheckoutWebhookTransform : WebhookTransform {
         TransformFeedbacks(serializer, GivingTypes.RegularGiving, checkout.RegularGiving?.Allocations, jObject);
         TransformSponsorships(serializer, GivingTypes.Donation, checkout.Donation?.Allocations, jObject, checkout.Timestamp);
         TransformSponsorships(serializer, GivingTypes.RegularGiving, checkout.RegularGiving?.Allocations, jObject, checkout.Timestamp);
-        TransformTags(jObject);
+        TransformTags(checkout, jObject);
         
         return jObject;
     }
@@ -114,8 +110,8 @@ public class CheckoutWebhookTransform : WebhookTransform {
         }
     }
     
-    private void TransformTags(JObject jObject) {
-        var language = LocalizationSettings.GetLanguageName(_cultureAccessor.GetCulture()) ?? Site.Language;
+    private void TransformTags(Entities.Checkout checkout, JObject jObject) {
+        var language = LocalizationSettings.GetLanguageName(checkout.Culture) ?? Site.Language;
 
         if (language.HasValue()) {
             AddTag(jObject, "SiteLanguageTag", language);

--- a/src/Giving/N3O.Umbraco.Giving.Checkout/Webhooks/CheckoutWebhookTransform.cs
+++ b/src/Giving/N3O.Umbraco.Giving.Checkout/Webhooks/CheckoutWebhookTransform.cs
@@ -1,5 +1,6 @@
 using Humanizer;
 using N3O.Umbraco.Content;
+using N3O.Umbraco.Context;
 using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Financial;
 using N3O.Umbraco.Giving.Allocations;
@@ -26,13 +27,16 @@ public class CheckoutWebhookTransform : WebhookTransform {
         AliasHelper<PaymentMethodSettingsContent<IPaymentMethodSettings>>.PropertyAlias(x => x.RestrictCollectionDaysTo);
 
     private readonly IContentCache _contentCache;
+    private readonly ICultureAccessor _cultureAccessor;
     private readonly IPriceCalculator _priceCalculator;
 
     public CheckoutWebhookTransform(IJsonProvider jsonProvider,
                                     IContentCache contentCache,
+                                    ICultureAccessor cultureAccessor,
                                     IPriceCalculator priceCalculator)
         : base(jsonProvider) {
         _contentCache = contentCache;
+        _cultureAccessor = cultureAccessor;
         _priceCalculator = priceCalculator;
     }
 
@@ -111,7 +115,8 @@ public class CheckoutWebhookTransform : WebhookTransform {
     }
     
     private void TransformTags(Entities.Checkout checkout, JObject jObject) {
-        var language = LocalizationSettings.GetLanguageName(checkout.Culture) ?? Site.Language;
+        var language = LocalizationSettings.GetLanguageName(_cultureAccessor.GetCulture(checkout.Culture)) ??
+                       Site.Language;
 
         if (language.HasValue()) {
             AddTag(jObject, "SiteLanguageTag", language);


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

The checkout webhook's `SiteLanguageTag` could report the wrong language for a donation. It was resolved at the moment the tag was written, and that happens inline on the request that completes the checkout — a payments API route with no routed content and no domain to resolve from. Culture resolution therefore fell back to the site default, so on a culture-varying site a donor giving in a non-default language was tagged with the default one. It went unnoticed because the default language is the correct answer for most visitors, so the failure is invisible unless you specifically test a second language.

This carries the culture on the `Checkout` entity instead of resolving it late. It is captured from `ICultureAccessor` on the checkout page requests, which are content-routed and where the accessor resolves the real culture, and persisted so it is still available when the tag is built. It is also refreshed on later page-routed visits, so a visitor who switches language part-way through the checkout is tagged with the language they actually completed in.

`TransformTags` reads the persisted value **through** `ICultureAccessor.GetCulture(culture)`, the explicit-argument overload, rather than using the field directly — so the accessor remains the single place a culture is resolved, and this file keeps its dependency on it.

Some details worth a reviewer's attention:

- **The refresh is opt-in per call site.** `GetOrCreateAsync` is reached both from the checkout page controllers and from `GET /umbraco/api/Checkout/current`, and the latter is an API route with no resolvable culture — refreshing there would overwrite a correct value with the site default, so only the two page controllers ask for it.
- **It is skipped once the checkout is complete.** The refresh saves the entity; every save runs `Checkout.OnSaving`, which dereferences the current stage, and that is null once the final stage completes. Skipping also means a completed donation's stored culture can no longer drift away from the tag already sent.
- **It writes with `RevisionBehaviour.Unchanged`**, because the checkout revision appears in the checkout API URLs and must not move mid-flow, and it only writes when the culture has actually changed.
- **This does make a checkout page GET a writer**, where before it only read. The window between its read and its write is a single string comparison, but it is worth naming: `Repository.UpdateAsync` carries a standing TODO that the UPDATE performs no revision check, and the account/consent/tax-status handlers and the payments scope all write without taking the accessor's lock. This change adds one more participant to that pre-existing gap rather than creating it; if you would rather the refresh did not write at all, the alternative is to accept that a mid-checkout language switch keeps the original language.
- The culture is persisted as a `string`, matching `ICultureAccessor.GetCulture()`. Happy to revisit if a typed value is preferred, but that would change the accessor's signature and belongs in its own change.
- The entity is serialised wholesale into the webhook body, so the payload now carries an additional top-level `culture` field alongside the corrected tag. This is deliberate — `[JsonIgnore]` would stop the value persisting at all, since the entity round-trips through the same serialiser.
- Checkouts already in flight when this deploys have no stored culture, so the accessor resolves as it does today and the existing fallback applies, unchanged.
- `refreshCulture` is ordered ahead of the cancellation token so the token stays last. That makes an existing positional call a compile error rather than a silent rebind, which is why `GetOrBeginCheckoutHandler` is in the diff.

## Test plan

Built the checkout project and a consuming site solution.

- [x] Builds with no errors and no new warnings
- [x] Donation completed end to end in the site's default language — tag reports that language
- [x] Donation completed end to end in a second, non-default language — tag reports that language (previously reported the default)
- [x] Donation created in one language, switched to a second part-way through, then completed — tag reports the language it was completed in
- [x] Persisted culture survives every entity revision from creation through to payment
- [x] `GET /umbraco/api/Checkout/current` called repeatedly does not overwrite an already-resolved culture
- [x] Checkout revision unchanged across a language switch
- [x] Completed checkout's thank-you page loaded under a different culture — renders, does not save, and leaves the stored culture and revision untouched
- [ ] Verified on staging after deploy
