### PR TITLE
Register a content type provider on the credential storage path

### DIFF
--- a/src/Storage/N3O.Umbraco.Storage.Azure/AzureStorageComposer.cs
+++ b/src/Storage/N3O.Umbraco.Storage.Azure/AzureStorageComposer.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using N3O.Umbraco.Composing;
 using N3O.Umbraco.Extensions;
@@ -46,6 +47,10 @@ public class AzureStorageComposer : Composer {
 
     private void ComposeWithIdentity(IUmbracoBuilder builder) {
         var container = AzureBlobStorage.GetMediaContainerClient(builder.Config);
+
+        // Umbraco does not register a content type provider; the stock Azure provider
+        // constructs its own, so the credential path must supply one the same way.
+        builder.Services.TryAddSingleton<IContentTypeProvider, FileExtensionContentTypeProvider>();
 
         builder.SetMediaFileSystem(provider => {
             var hostingEnvironment = provider.GetRequiredService<IHostingEnvironment>();


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

Found by the mhfr staging canary: Umbraco 13 does not register `IContentTypeProvider` in DI — the stock Azure blob provider constructs its own `FileExtensionContentTypeProvider` — so the credential path's `GetRequiredService<IContentTypeProvider>()` aborted the host at boot (`InvalidOperationException: No service for type … IContentTypeProvider`). The credential path now `TryAdd`s the same provider the stock path uses; a host that already registers one keeps its own. Connection-string mode untouched.

The canary otherwise proved the chain before dying: the pod read its new vault via workload identity and installed Hangfire objects on `site-mhfr-stg` — the failure was purely this DI gap.

## Test plan

- [x] Project builds clean
- [ ] mhfr staging pod boots to healthy on the republished package