### PR TITLE
Allow a CDN cache entry to be invalidated before its max age

### DIFF
--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/PlatformsConstants.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/PlatformsConstants.cs
@@ -92,6 +92,19 @@ public static class PlatformsConstants {
         public const string ZakatSettings = "zakatSettings";
     }
 
+    public static class Webhooks {
+        public static class EventTypes {
+            public static class Crowdfunder {
+                public const string Created = "crowdfunder.created";
+                public const string Updated = "crowdfunder.updated";
+            }
+        }
+
+        public static class HookIds {
+            public const string Crowdfunder = nameof(Crowdfunder);
+        }
+    }
+
     public static class Zakat {
         public static class Settings {
             public static class Calculator {

--- a/src/Cloud/N3O.Umbraco.Cloud.Platforms/Webhooks/CrowdfunderReceiver.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud.Platforms/Webhooks/CrowdfunderReceiver.cs
@@ -1,0 +1,77 @@
+using N3O.Umbraco.Cloud.Platforms.Models;
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Json;
+using N3O.Umbraco.Webhooks.Attributes;
+using N3O.Umbraco.Webhooks.Extensions;
+using N3O.Umbraco.Webhooks.Models;
+using N3O.Umbraco.Webhooks.Receivers;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using static N3O.Umbraco.Cloud.Platforms.PlatformsConstants.Webhooks;
+
+namespace N3O.Umbraco.Cloud.Platforms.Webhooks;
+
+[WebhookReceiver(HookIds.Crowdfunder)]
+public class CrowdfunderReceiver : WebhookReceiver {
+    private readonly ICdnClient _cdnClient;
+    private readonly IJsonProvider _jsonProvider;
+
+    public CrowdfunderReceiver(ICdnClient cdnClient, IJsonProvider jsonProvider) {
+        _cdnClient = cdnClient;
+        _jsonProvider = jsonProvider;
+    }
+
+    protected override async Task ProcessAsync(WebhookPayload payload, CancellationToken cancellationToken) {
+        var webhookCrowdfunder = payload.GetBody<WebhookCrowdfunder>(_jsonProvider);
+        var eventType = payload.GetEventType();
+
+        switch (eventType) {
+            case EventTypes.Crowdfunder.Created:
+            case EventTypes.Crowdfunder.Updated:
+                await EvictAsync(webhookCrowdfunder, cancellationToken);
+
+                break;
+        }
+    }
+
+    private async Task EvictAsync(WebhookCrowdfunder webhookCrowdfunder, CancellationToken cancellationToken) {
+        if (webhookCrowdfunder == null || !webhookCrowdfunder.HasValue(x => x.PagePublishedPath)) {
+            return;
+        }
+
+        foreach (var pagePublishedPath in webhookCrowdfunder.OrEmpty(x => x.PagePublishedPathsHistory)) {
+            _cdnClient.Evict(pagePublishedPath);
+        }
+
+        _cdnClient.Evict(webhookCrowdfunder.PagePublishedPath);
+
+        await EvictMergeModelsAsync(webhookCrowdfunder.PagePublishedPath, cancellationToken);
+    }
+
+    private async Task EvictMergeModelsAsync(string pagePublishedPath, CancellationToken cancellationToken) {
+        var publishedContentResult = await _cdnClient.DownloadPublishedContentAsync(pagePublishedPath,
+                                                                                   cancellationToken);
+
+        if (publishedContentResult.NotFound || publishedContentResult.Error) {
+            return;
+        }
+
+        var content = publishedContentResult.Content;
+        var publishedPlatformsPage = _jsonProvider.DeserializeDynamicTo<PublishedPlatformsPage>(content);
+
+        foreach (var mergeModel in publishedPlatformsPage.OrEmpty(x => x.MergeModels)) {
+            _cdnClient.Evict(mergeModel.Path);
+        }
+    }
+
+    public class WebhookCrowdfunder {
+        public WebhookCrowdfunder(string pagePublishedPath, IEnumerable<string> pagePublishedPathsHistory) {
+            PagePublishedPath = pagePublishedPath;
+            PagePublishedPathsHistory = pagePublishedPathsHistory;
+        }
+
+        public string PagePublishedPath { get; }
+        public IEnumerable<string> PagePublishedPathsHistory { get; }
+    }
+}

--- a/src/Cloud/N3O.Umbraco.Cloud/Models/CdnDownloadResult.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud/Models/CdnDownloadResult.cs
@@ -38,16 +38,24 @@ public class CdnDownloadResult {
             return false;
         }
     }
-
-    public static CdnDownloadResult ForNotFound(IClock clock) {
-        return new CdnDownloadResult(false, false, null, clock.GetCurrentInstant());
+    
+    public bool WasInvalidated(Instant? invalidatedAt) {
+        if (invalidatedAt == null) {
+            return false;
+        }
+        
+        return Timestamp <= invalidatedAt.Value;
     }
 
-    public static CdnDownloadResult ForError(IClock clock) {
-        return new CdnDownloadResult(false, true, null, clock.GetCurrentInstant());
+    public static CdnDownloadResult ForNotFound(Instant startedAt) {
+        return new CdnDownloadResult(false, false, null, startedAt);
     }
 
-    public static CdnDownloadResult ForSuccess(IClock clock, string content) {
-        return new CdnDownloadResult(true, false, content, clock.GetCurrentInstant());
+    public static CdnDownloadResult ForError(Instant startedAt) {
+        return new CdnDownloadResult(false, true, null, startedAt);
+    }
+
+    public static CdnDownloadResult ForSuccess(Instant startedAt, string content) {
+        return new CdnDownloadResult(true, false, content, startedAt);
     }
 }

--- a/src/Cloud/N3O.Umbraco.Cloud/Services/Cdn/CdnClient.I.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud/Services/Cdn/CdnClient.I.cs
@@ -15,4 +15,6 @@ public interface ICdnClient {
     
     Task<PublishedContentResult> DownloadPublishedContentAsync(string path,
                                                                CancellationToken cancellationToken = default);
+
+    void Evict(string path);
 }

--- a/src/Cloud/N3O.Umbraco.Cloud/Services/Cdn/CdnClient.cs
+++ b/src/Cloud/N3O.Umbraco.Cloud/Services/Cdn/CdnClient.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json.Linq;
 using NodaTime;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -22,6 +23,7 @@ public class CdnClient : ICdnClient {
     private static readonly SemaphoreSlim ConcurrencyLimit = new(10, 10);
     private static readonly ConcurrentDictionary<string, CdnDownloadResult> Downloads = new(StringComparer.InvariantCultureIgnoreCase);
     private static readonly ConcurrentDictionary<string, Lazy<Task<CdnDownloadResult>>> Refreshes = new(StringComparer.InvariantCultureIgnoreCase);
+    private static readonly ConcurrentDictionary<string, Instant> InvalidatedAt = new(StringComparer.InvariantCultureIgnoreCase);
 
     private readonly ICloudUrl _cloudUrl;
     private readonly IClock _clock;
@@ -83,10 +85,19 @@ public class CdnClient : ICdnClient {
         }
     }
 
+    public void Evict(string path) {
+        var publishedUrl = GetPublishedContentUrl(path);
+
+        InvalidatedAt[publishedUrl] = _clock.GetCurrentInstant();
+    }
+
     private async Task<CdnDownloadResult> FetchAsync(string publishedUrl, CancellationToken cancellationToken) {
         var download = Downloads.GetOrDefault(publishedUrl);
 
-        if (download == null || download.IsExpired(_clock) || download.CanRetry(_clock)) {
+        if (download == null ||
+            download.IsExpired(_clock) ||
+            download.CanRetry(_clock) ||
+            download.WasInvalidated(GetInvalidatedAt(publishedUrl))) {
             // Coalesce refreshes per URL so a failing CDN cannot pile up in-flight fetches and drain ConcurrencyLimit.
             var refresh = Refreshes.GetOrAdd(publishedUrl,
                                              url => new Lazy<Task<CdnDownloadResult>>(() => RefreshAsync(url)));
@@ -99,33 +110,59 @@ public class CdnClient : ICdnClient {
 
     private async Task<CdnDownloadResult> RefreshAsync(string publishedUrl) {
         try {
-            var cdnDownloadResult = await DownloadStringAsync(publishedUrl, CancellationToken.None);
+            var startedAt = _clock.GetCurrentInstant();
+            var cdnDownloadResult = await DownloadStringAsync(publishedUrl, startedAt, CancellationToken.None);
 
             // A cached success is retained when a later refresh fails.
-            return Downloads.AddOrUpdate(publishedUrl,
-                                         cdnDownloadResult,
-                                         (_, existing) => cdnDownloadResult.Success || !existing.Success
-                                                              ? cdnDownloadResult
-                                                              : existing);
+            var result = Downloads.AddOrUpdate(publishedUrl,
+                                               cdnDownloadResult,
+                                               (_, existing) => cdnDownloadResult.Success || !existing.Success
+                                                                    ? cdnDownloadResult
+                                                                    : existing);
+
+            ClearInvalidation(publishedUrl, startedAt);
+
+            return result;
         } finally {
             Refreshes.TryRemove(publishedUrl, out _);
         }
     }
-    
+
+    private void ClearInvalidation(string publishedUrl, Instant startedAt) {
+        var invalidatedAt = GetInvalidatedAt(publishedUrl);
+
+        if (invalidatedAt == null) {
+            return;
+        }
+
+        if (invalidatedAt.Value < startedAt) {
+            InvalidatedAt.TryRemove(new KeyValuePair<string, Instant>(publishedUrl, invalidatedAt.Value));
+        }
+    }
+
+    private Instant? GetInvalidatedAt(string publishedUrl) {
+        if (InvalidatedAt.TryGetValue(publishedUrl, out var invalidatedAt)) {
+            return invalidatedAt;
+        } else {
+            return null;
+        }
+    }
+
     private async Task<CdnDownloadResult> DownloadStringAsync(string publishedUrl,
+                                                              Instant startedAt,
                                                               CancellationToken cancellationToken) {
         try {
             var download = await GetStringRateLimitedAsync(publishedUrl, cancellationToken);
 
-            return CdnDownloadResult.ForSuccess(_clock, download);
+            return CdnDownloadResult.ForSuccess(startedAt, download);
         } catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound) {
             _logger.LogDebug("CDN 404 for {PublishedUrl}", publishedUrl);
 
-            return CdnDownloadResult.ForNotFound(_clock);
+            return CdnDownloadResult.ForNotFound(startedAt);
         } catch (Exception ex) {
             _logger.LogWarning(ex, "Could not download {PublishedUrl}", publishedUrl);
 
-            return CdnDownloadResult.ForError(_clock);
+            return CdnDownloadResult.ForError(startedAt);
         }
     }
     


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

`CdnClient` caches published content in process for five minutes, and a not-found
result for fifteen, with no way to drop an entry early. Content that has just
changed therefore stays stale for the remainder of its window, and a page that
returned 404 before its content existed stays a 404 for a quarter of an hour.

`ICdnClient` gains `Evict(path)`. An eviction records an instant per URL rather
than removing the cached entry, and `FetchAsync` treats an entry whose fetch
started at or before that instant as stale. Recording rather than removing for two
reasons:

- `FetchAsync` ends in a dictionary indexer, which is safe today only because
  entries are added and updated but never removed. Recording keeps that true.
- Refreshes are coalesced per URL, and a refresh already in flight still writes its
  result back when it completes. Removing the entry would not prevent that write,
  so a fetch that started before the content changed could reinstate the old body
  as fresh — for newly created content, reinstating a 404 for another fifteen
  minutes.

For the second point to hold, `CdnDownloadResult.Timestamp` is now the instant the
fetch *began* rather than the instant it completed, so an in-flight fetch is judged
on when it started. This shortens the effective freshness window of every cached
download by its own fetch latency, which is sub-second against a five-minute
budget.

Also adds a crowdfunder webhook receiver that evicts a crowdfunder's current and
historical page paths, together with the merge models its page declares, when the
crowdfunding service reports the crowdfunder created or updated. The receiver is
dormant until a webhook endpoint is configured against it, and no-ops on payloads
that predate the companion backend change that supplies the paths, so that change
deploys first.

Eviction is per process. The webhook is handled as a background job, so the entry
is dropped in whichever process runs it; that is sufficient because these sites run
a single replica.

## Test plan

There is no test project in this repository, so the mechanism was driven from a
scratch console harness that constructs the real `CdnClient` against a local HTTP
server with a controllable clock. Each scenario, then the same harness with the fix
undone.

With the change:

```
Scenario A - evict drops a cached success inside its 5-minute window
  [PASS] first read is v1          [PASS] still cached as v1     [PASS] after evict reads v2
Scenario B - evict drops a cached 404 inside its 15-minute window
  [PASS] first read is null        [PASS] still cached as null   [PASS] after evict reads created
Scenario C - an in-flight fetch started before the evict cannot resurrect stale content
  [PASS] in-flight caller still sees old                         [PASS] next read is new, not old
  (server hits on /c: 2)
ALL SCENARIOS PASSED
```

Reverse check 1, `WasInvalidated` forced to `false` — every eviction assertion
fails, so the harness is actually exercising the new path:

```
  [FAIL] after evict reads v2: expected "v2", got "v1"
  [FAIL] after evict reads created: expected "created", got <null>
  [FAIL] next read is new, not old: expected "new", got "old"
3 ASSERTION(S) FAILED
```

Reverse check 2, stamping the result at fetch completion instead of fetch start —
A and B still pass and only C fails, isolating the fetch-start stamp as what closes
the in-flight race:

```
Scenario C - an in-flight fetch started before the evict cannot resurrect stale content
  [PASS] in-flight caller still sees old
  [FAIL] next read is new, not old: expected "new", got "old"
  (server hits on /c: 1)
```

- [x] `dotnet build N3O.Umbraco.Cloud.Platforms.csproj` — 0 errors, 5 warnings, all
      pre-existing and none in the touched files
- [x] Confirmed the receiver and the CDN download path build the same cache key:
      both resolve through `GetPublishedContentUrl(path)`, and the merge model paths
      evicted are the same `PublishedFileInfo.Path` values the page walker fetches
- [ ] Not exercised at runtime: no webhook posted to a running site, and no
      published crowdfunder observed end to end
