### PR TITLE
Sync the Typesense package with the backend implementation

### DIFF
--- a/src/Search/N3O.Umbraco.Search.Typesense/Attributes/FieldAttribute.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Attributes/FieldAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Typesense;
 
 namespace N3O.Umbraco.Search.Typesense.Attributes;
@@ -27,11 +27,11 @@ public class FieldAttribute : Attribute {
     
     public string Name { get; }
     public FieldType Type { get; }
-    public bool Facet { get; set; }
-    public bool Required { get; set; }
-    public bool Index { get; set; }
-    public bool Sort { get; set; }
-    public bool Infix { get; set; }
-    public string Locale { get; set; }
-    public int NumberOfDimensions { get; set; }
+    public bool Required { get; }
+    public bool Index { get; }
+    public bool Facet { get; }
+    public bool Sort { get; }
+    public bool Infix { get; }
+    public string Locale { get; }
+    public int NumberOfDimensions { get; }
 }

--- a/src/Search/N3O.Umbraco.Search.Typesense/Attributes/IndexAttribute.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Attributes/IndexAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense.Attributes;
+
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
+public class IndexAttribute : Attribute {
+    public IndexAttribute(string name, FieldType type, bool required) {
+        Name = name;
+        Type = type;
+        Required = required;
+    }
+
+    public string Name { get; }
+    public FieldType Type { get; }
+    public bool Required { get; }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Commands/MigrateCollectionsCommand.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Commands/MigrateCollectionsCommand.cs
@@ -1,0 +1,5 @@
+using N3O.Umbraco.Mediator;
+
+namespace N3O.Umbraco.Search.Typesense.Commands;
+
+public class MigrateCollectionsCommand : Request<None, None> { }

--- a/src/Search/N3O.Umbraco.Search.Typesense/Extensions/TypesenseClauseBuilderExtensions.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Extensions/TypesenseClauseBuilderExtensions.cs
@@ -1,0 +1,274 @@
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Search.Typesense.Models;
+using N3O.Umbraco.Search.Typesense.Queries;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace N3O.Umbraco.Search.Typesense.Extensions;
+
+public static class TypesenseClauseBuilderExtensions {
+    public static ITypesenseClauseBuilder<T> Eq<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                         Expression<Func<T, TKey>> pathExpression,
+                                                         TKey value)
+        where T : SearchDocument {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:=@v")
+                                               .WithParameter("v", value);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> NotEq<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                            Expression<Func<T, TKey>> pathExpression,
+                                                            TKey value)
+        where T : SearchDocument {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:!=@v")
+                                               .WithParameter("v", value);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> In<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                         Expression<Func<T, TKey>> pathExpression,
+                                                         IEnumerable<TKey> values)
+        where T : SearchDocument {
+        var array = values.OrEmpty().ToArray();
+
+        if (array.Length == 0) {
+            return c;
+        }
+
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:=[@v]")
+                                               .WithParameter("v", array);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> NotIn<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                            Expression<Func<T, TKey>> pathExpression,
+                                                            IEnumerable<TKey> values)
+        where T : SearchDocument {
+        var array = values.OrEmpty().ToArray();
+
+        if (array.Length == 0) {
+            return c;
+        }
+
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:!=[@v]")
+                                               .WithParameter("v", array);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Gt<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                         Expression<Func<T, TKey?>> pathExpression,
+                                                         TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:>@v")
+                                               .WithParameter("v", value);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Gte<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                          Expression<Func<T, TKey?>> pathExpression,
+                                                          TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:>=@v")
+                                               .WithParameter("v", value);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Lt<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                         Expression<Func<T, TKey?>> pathExpression,
+                                                         TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:<@v")
+                                               .WithParameter("v", value);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Lte<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                          Expression<Func<T, TKey?>> pathExpression,
+                                                          TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:<=@v")
+                                               .WithParameter("v", value);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Between<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                              Expression<Func<T, TKey?>> pathExpression,
+                                                              TKey min,
+                                                              TKey max)
+        where T : SearchDocument
+        where TKey : struct {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:[@min..@max]")
+                                               .WithParameter("min", min)
+                                               .WithParameter("max", max);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Between<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                              Expression<Func<T, TKey?>> pathExpression,
+                                                              Range<TKey?> range)
+        where T : SearchDocument
+        where TKey : struct {
+        if (range == null || (!range.From.HasValue && !range.To.HasValue)) {
+            return c;
+        }
+
+        if (range.From.HasValue && !range.To.HasValue) {
+            return c.Gte(pathExpression, range.From.GetValueOrThrow());
+        }
+
+        if (!range.From.HasValue && range.To.HasValue) {
+            return c.Lte(pathExpression, range.To.GetValueOrThrow());
+        }
+
+        return c.Between(pathExpression, range.From.GetValueOrThrow(), range.To.GetValueOrThrow());
+    }
+
+    public static ITypesenseClauseBuilder<T> StartsWith<T>(this ITypesenseClauseBuilder<T> c,
+                                                           Expression<Func<T, string>> pathExpression,
+                                                           string prefix)
+        where T : SearchDocument {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:=@v*")
+                                               .WithParameter("v", prefix);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Partial<T>(this ITypesenseClauseBuilder<T> c,
+                                                        Expression<Func<T, string>> pathExpression,
+                                                        string word)
+        where T : SearchDocument {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:@v")
+                                               .WithParameter("v", word);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Contains<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                               Expression<Func<T, IEnumerable<TKey>>> pathExpression,
+                                                               TKey value)
+        where T : SearchDocument {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:=@v")
+                                               .WithParameter("v", value);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> ContainsAny<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                                  Expression<Func<T, IEnumerable<TKey>>> pathExpression,
+                                                                  IEnumerable<TKey> values)
+        where T : SearchDocument {
+        var array = values.OrEmpty().ToArray();
+
+        if (array.Length == 0) {
+            return c;
+        }
+
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:=[@v]")
+                                               .WithParameter("v", array);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> ContainsAll<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                                  Expression<Func<T, IEnumerable<TKey>>> pathExpression,
+                                                                  IEnumerable<TKey> values)
+        where T : SearchDocument {
+        foreach (var value in values.OrEmpty()) {
+            c.Contains(pathExpression, value);
+        }
+
+        return c;
+    }
+
+    public static ITypesenseClauseBuilder<T> Gt<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                         Expression<Func<T, TKey>> pathExpression,
+                                                         TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:>@v")
+                                               .WithParameter("v", value);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Gte<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                          Expression<Func<T, TKey>> pathExpression,
+                                                          TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:>=@v")
+                                               .WithParameter("v", value);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Lt<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                         Expression<Func<T, TKey>> pathExpression,
+                                                         TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:<@v")
+                                               .WithParameter("v", value);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Lte<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                          Expression<Func<T, TKey>> pathExpression,
+                                                          TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:<=@v")
+                                               .WithParameter("v", value);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Between<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                              Expression<Func<T, TKey>> pathExpression,
+                                                              TKey min,
+                                                              TKey max)
+        where T : SearchDocument
+        where TKey : struct {
+        var clause = ParameterizedTypesenseText.Create(pathExpression, "þ:[@min..@max]")
+                                               .WithParameter("min", min)
+                                               .WithParameter("max", max);
+
+        return c.And(clause);
+    }
+
+    public static ITypesenseClauseBuilder<T> Between<T, TKey>(this ITypesenseClauseBuilder<T> c,
+                                                              Expression<Func<T, TKey>> pathExpression,
+                                                              Range<TKey?> range)
+        where T : SearchDocument
+        where TKey : struct {
+        if (range == null || (!range.From.HasValue && !range.To.HasValue)) {
+            return c;
+        }
+
+        if (range.From.HasValue && !range.To.HasValue) {
+            return c.Gte(pathExpression, range.From.GetValueOrThrow());
+        }
+
+        if (!range.From.HasValue && range.To.HasValue) {
+            return c.Lte(pathExpression, range.To.GetValueOrThrow());
+        }
+
+        return c.Between(pathExpression, range.From.GetValueOrThrow(), range.To.GetValueOrThrow());
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Extensions/TypesenseSearchBuilderExtensions.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Extensions/TypesenseSearchBuilderExtensions.cs
@@ -1,0 +1,100 @@
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Search.Typesense.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace N3O.Umbraco.Search.Typesense.Extensions;
+
+public static class TypesenseSearchBuilderExtensions {
+    public static ITypesenseSearchBuilder<T> Eq<T, TKey>(this ITypesenseSearchBuilder<T> q,
+                                                         Expression<Func<T, TKey>> pathExpression,
+                                                         TKey value)
+        where T : SearchDocument {
+        return q.Filter(c => c.Eq(pathExpression, value));
+    }
+
+    public static ITypesenseSearchBuilder<T> NotEq<T, TKey>(this ITypesenseSearchBuilder<T> q,
+                                                            Expression<Func<T, TKey>> pathExpression,
+                                                            TKey value)
+        where T : SearchDocument {
+        return q.Filter(c => c.NotEq(pathExpression, value));
+    }
+
+    public static ITypesenseSearchBuilder<T> In<T, TKey>(this ITypesenseSearchBuilder<T> q,
+                                                         Expression<Func<T, TKey>> pathExpression,
+                                                         IEnumerable<TKey> values)
+        where T : SearchDocument {
+        return q.Filter(c => c.In(pathExpression, values));
+    }
+
+    public static ITypesenseSearchBuilder<T> NotIn<T, TKey>(this ITypesenseSearchBuilder<T> q,
+                                                            Expression<Func<T, TKey>> pathExpression,
+                                                            IEnumerable<TKey> values)
+        where T : SearchDocument {
+        return q.Filter(c => c.NotIn(pathExpression, values));
+    }
+
+    public static ITypesenseSearchBuilder<T> Gt<T, TKey>(this ITypesenseSearchBuilder<T> q,
+                                                         Expression<Func<T, TKey?>> pathExpression,
+                                                         TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        return q.Filter(c => c.Gt(pathExpression, value));
+    }
+
+    public static ITypesenseSearchBuilder<T> Gte<T, TKey>(this ITypesenseSearchBuilder<T> q,
+                                                          Expression<Func<T, TKey?>> pathExpression,
+                                                          TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        return q.Filter(c => c.Gte(pathExpression, value));
+    }
+
+    public static ITypesenseSearchBuilder<T> Lt<T, TKey>(this ITypesenseSearchBuilder<T> q,
+                                                         Expression<Func<T, TKey?>> pathExpression,
+                                                         TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        return q.Filter(c => c.Lt(pathExpression, value));
+    }
+
+    public static ITypesenseSearchBuilder<T> Lte<T, TKey>(this ITypesenseSearchBuilder<T> q,
+                                                          Expression<Func<T, TKey?>> pathExpression,
+                                                          TKey value)
+        where T : SearchDocument
+        where TKey : struct {
+        return q.Filter(c => c.Lte(pathExpression, value));
+    }
+
+    public static ITypesenseSearchBuilder<T> Between<T, TKey>(this ITypesenseSearchBuilder<T> q,
+                                                              Expression<Func<T, TKey?>> pathExpression,
+                                                              TKey min,
+                                                              TKey max)
+        where T : SearchDocument
+        where TKey : struct {
+        return q.Filter(c => c.Between(pathExpression, min, max));
+    }
+
+    public static ITypesenseSearchBuilder<T> Between<T, TKey>(this ITypesenseSearchBuilder<T> q,
+                                                              Expression<Func<T, TKey?>> pathExpression,
+                                                              Range<TKey?> range)
+        where T : SearchDocument
+        where TKey : struct {
+        return q.Filter(c => c.Between(pathExpression, range));
+    }
+
+    public static ITypesenseSearchBuilder<T> StartsWith<T>(this ITypesenseSearchBuilder<T> q,
+                                                           Expression<Func<T, string>> pathExpression,
+                                                           string prefix)
+        where T : SearchDocument {
+        return q.Filter(c => c.StartsWith(pathExpression, prefix));
+    }
+
+    public static ITypesenseSearchBuilder<T> Partial<T>(this ITypesenseSearchBuilder<T> q,
+                                                        Expression<Func<T, string>> pathExpression,
+                                                        string word)
+        where T : SearchDocument {
+        return q.Filter(c => c.Partial(pathExpression, word));
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Extensions/TypesenseSearchShapingExtensions.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Extensions/TypesenseSearchShapingExtensions.cs
@@ -1,0 +1,91 @@
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Search.Typesense.Models;
+using System;
+using System.Globalization;
+using System.Linq.Expressions;
+
+namespace N3O.Umbraco.Search.Typesense.Extensions;
+
+public static class TypesenseSearchShapingExtensions {
+    public static ITypesenseSearchBuilder<T> Page<T>(this ITypesenseSearchBuilder<T> q, int page, int perPage)
+        where T : SearchDocument {
+        return q.Custom(p => {
+            p.Page = page;
+            p.PerPage = perPage;
+        });
+    }
+
+    public static ITypesenseSearchBuilder<T> Limit<T>(this ITypesenseSearchBuilder<T> q, int limit)
+        where T : SearchDocument {
+        return q.Custom(p => p.PerPage = limit);
+    }
+
+    public static ITypesenseSearchBuilder<T> Highlight<T, TField>(this ITypesenseSearchBuilder<T> q,
+                                                                  Expression<Func<T, TField>> pathExpression)
+        where T : SearchDocument {
+        var field = TypesenseField.Get(pathExpression);
+
+        return q.Custom(p => p.HighlightFields = AppendCsv(p.HighlightFields, field));
+    }
+
+    public static ITypesenseSearchBuilder<T> HighlightFull<T, TField>(this ITypesenseSearchBuilder<T> q,
+                                                                      Expression<Func<T, TField>> pathExpression)
+        where T : SearchDocument {
+        var field = TypesenseField.Get(pathExpression);
+
+        return q.Custom(p => p.HighlightFullFields = AppendCsv(p.HighlightFullFields, field));
+    }
+
+    public static ITypesenseSearchBuilder<T> HighlightTag<T>(this ITypesenseSearchBuilder<T> q,
+                                                             string startTag,
+                                                             string endTag)
+        where T : SearchDocument {
+        return q.Custom(p => {
+            p.HighlightStartTag = startTag;
+            p.HighlightEndTag = endTag;
+        });
+    }
+
+    public static ITypesenseSearchBuilder<T> FacetBy<T, TField>(this ITypesenseSearchBuilder<T> q,
+                                                                Expression<Func<T, TField>> pathExpression)
+        where T : SearchDocument {
+        var field = TypesenseField.Get(pathExpression);
+
+        return q.Custom(p => p.FacetBy = AppendCsv(p.FacetBy, field));
+    }
+
+    public static ITypesenseSearchBuilder<T> MaxFacetValues<T>(this ITypesenseSearchBuilder<T> q, int max)
+        where T : SearchDocument {
+        return q.Custom(p => p.MaxFacetValues = max);
+    }
+
+    public static ITypesenseSearchBuilder<T> Include<T, TField>(this ITypesenseSearchBuilder<T> q,
+                                                                Expression<Func<T, TField>> pathExpression)
+        where T : SearchDocument {
+        var field = TypesenseField.Get(pathExpression);
+
+        return q.Custom(p => p.IncludeFields = AppendCsv(p.IncludeFields, field));
+    }
+
+    public static ITypesenseSearchBuilder<T> Exclude<T, TField>(this ITypesenseSearchBuilder<T> q,
+                                                                Expression<Func<T, TField>> pathExpression)
+        where T : SearchDocument {
+        var field = TypesenseField.Get(pathExpression);
+
+        return q.Custom(p => p.ExcludeFields = AppendCsv(p.ExcludeFields, field));
+    }
+
+    public static ITypesenseSearchBuilder<T> MaxTypos<T>(this ITypesenseSearchBuilder<T> q, int max)
+        where T : SearchDocument {
+        return q.Custom(p => p.NumberOfTypos = max.ToString(CultureInfo.InvariantCulture));
+    }
+
+    public static ITypesenseSearchBuilder<T> PrefixMatching<T>(this ITypesenseSearchBuilder<T> q, bool enabled = true)
+        where T : SearchDocument {
+        return q.Custom(p => p.Prefix = enabled);
+    }
+
+    private static string AppendCsv(string existing, string newValue) {
+        return existing.HasValue() ? $"{existing},{newValue}" : newValue;
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Handlers/MigrateCollectionsHandler.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Handlers/MigrateCollectionsHandler.cs
@@ -1,0 +1,199 @@
+using N3O.Umbraco.Content;
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Mediator;
+using N3O.Umbraco.Parameters;
+using N3O.Umbraco.Scheduler;
+using N3O.Umbraco.Scheduler.Extensions;
+using N3O.Umbraco.Search.Typesense.Commands;
+using N3O.Umbraco.Search.Typesense.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense.Handlers;
+
+public class MigrateCollectionsHandler : IRequestHandler<MigrateCollectionsCommand, None, None> {
+    private readonly ITypesenseClient _typesenseClient;
+    private readonly IReadOnlyList<ISearchIndexer> _searchIndexers;
+    private readonly IContentLocator _contentLocator;
+    private readonly IBackgroundJob _backgroundJob;
+
+    public MigrateCollectionsHandler(ITypesenseClient typesenseClient,
+                                     IEnumerable<ISearchIndexer> searchIndexers,
+                                     IContentLocator contentLocator,
+                                     IBackgroundJob backgroundJob) {
+        _typesenseClient = typesenseClient;
+        _searchIndexers = searchIndexers.OrEmpty().ToList();
+        _contentLocator = contentLocator;
+        _backgroundJob = backgroundJob;
+    }
+
+    public async Task<None> Handle(MigrateCollectionsCommand req, CancellationToken cancellationToken) {
+        if (_typesenseClient.HasValue()) {
+            foreach (var collection in TypesenseHelper.GetAllCollections()) {
+                await MigrateCollectionAsync(collection, cancellationToken);
+            }
+        }
+
+        return None.Empty;
+    }
+
+    private async Task MigrateCollectionAsync(CollectionInfo collectionInfo, CancellationToken cancellationToken) {
+        var aliasName = collectionInfo.Name.Resolve();
+        var newPhysicalName = GetPhysicalCollectionName(aliasName, collectionInfo.Version);
+        var existing = await TryGetCollectionAsync(aliasName, cancellationToken);
+
+        if (existing == null) {
+            cancellationToken.ThrowIfCancellationRequested();
+            await CreateCollectionAsync(newPhysicalName, collectionInfo);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await _typesenseClient.UpsertCollectionAlias(aliasName, new CollectionAlias(newPhysicalName));
+
+            EnqueueIndexing(collectionInfo);
+
+            return;
+        }
+
+        if (!IsOldVersion(existing, collectionInfo)) {
+            return;
+        }
+
+        var alias = await TryGetAliasAsync(aliasName, cancellationToken);
+
+        // A site indexed before collections were versioned has a real collection, not an alias, at the alias name
+        var isLegacyCollection = alias == null;
+        var oldPhysicalName = isLegacyCollection ? aliasName : alias.CollectionName;
+
+        var documentIds = await GetAllDocumentIdsAsync(oldPhysicalName, cancellationToken);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await TryDeleteCollectionAsync(newPhysicalName);
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await CreateCollectionAsync(newPhysicalName, collectionInfo);
+
+        await ReindexAllAsync(collectionInfo, documentIds, newPhysicalName, cancellationToken);
+
+        // Typesense cannot hold an alias and a collection under one name, so the legacy collection goes first
+        if (isLegacyCollection) {
+            cancellationToken.ThrowIfCancellationRequested();
+            await TryDeleteCollectionAsync(oldPhysicalName);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        await _typesenseClient.UpsertCollectionAlias(aliasName, new CollectionAlias(newPhysicalName));
+
+        if (!isLegacyCollection) {
+            cancellationToken.ThrowIfCancellationRequested();
+            await TryDeleteCollectionAsync(oldPhysicalName);
+        }
+    }
+
+    private async Task ReindexAllAsync(CollectionInfo collectionInfo,
+                                       IReadOnlyList<string> documentIds,
+                                       string targetCollectionName,
+                                       CancellationToken cancellationToken) {
+        var indexers = _searchIndexers.Where(x => x.IsIndexerFor(collectionInfo.Name)).ToList();
+
+        foreach (var documentId in documentIds) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!SearchDocument.TryParseId(documentId, out var contentKey, out var culture)) {
+                continue;
+            }
+
+            var publishedContent = _contentLocator.ById(contentKey);
+
+            if (publishedContent == null) {
+                continue;
+            }
+
+            foreach (var indexer in indexers.Where(x => x.CanIndex(publishedContent))) {
+                await indexer.IndexAsync(publishedContent, culture, targetCollectionName);
+            }
+        }
+    }
+
+    private void EnqueueIndexing(CollectionInfo collectionInfo) {
+        foreach (var contentType in collectionInfo.ContentTypeAliases.OrEmpty()) {
+            _backgroundJob.EnqueueCommand<IndexContentsOfTypeCommand>(m => m.Add<ContentType>(contentType), contentType);
+        }
+    }
+
+    private async Task<CollectionResponse> TryGetCollectionAsync(string collectionName,
+                                                                 CancellationToken cancellationToken) {
+        try {
+            return await _typesenseClient.RetrieveCollection(collectionName, cancellationToken);
+        } catch (TypesenseApiNotFoundException) {
+            return null;
+        }
+    }
+
+    private async Task<CollectionAliasResponse> TryGetAliasAsync(string aliasName, CancellationToken cancellationToken) {
+        try {
+            return await _typesenseClient.RetrieveCollectionAlias(aliasName, cancellationToken);
+        } catch (TypesenseApiNotFoundException) {
+            return null;
+        }
+    }
+
+    private async Task TryDeleteCollectionAsync(string collectionName) {
+        try {
+            await _typesenseClient.DeleteCollection(collectionName);
+        } catch (TypesenseApiNotFoundException) { }
+    }
+
+    private async Task CreateCollectionAsync(string physicalCollectionName, CollectionInfo collectionInfo) {
+        var metadata = new Dictionary<string, object>();
+        metadata.Add(TypesenseConstants.MetadataKeys.Version, collectionInfo.Version);
+
+        // Schema is a third-party record with init-only properties, so an object initializer is the only way to set them
+        var schema = new Schema(physicalCollectionName, collectionInfo.Fields) {
+            EnableNestedFields = true,
+            Metadata = metadata
+        };
+
+        await _typesenseClient.CreateCollection(schema);
+    }
+
+    private async Task<IReadOnlyList<string>> GetAllDocumentIdsAsync(string physicalCollectionName,
+                                                                     CancellationToken cancellationToken) {
+        var exportParameters = new ExportParameters();
+        exportParameters.IncludeFields = "id";
+
+        var documents = await _typesenseClient.ExportDocuments<ExportedDocument>(physicalCollectionName,
+                                                                                 exportParameters,
+                                                                                 cancellationToken);
+
+        return documents.Select(x => x.Id).ToList();
+    }
+
+    private bool IsOldVersion(CollectionResponse collection, CollectionInfo collectionInfo) {
+        var metadataVersion = GetVersionFromMetadata(collection);
+
+        return metadataVersion != collectionInfo.Version;
+    }
+
+    private int? GetVersionFromMetadata(CollectionResponse collection) {
+        var raw = collection?.Metadata?.TryGet(TypesenseConstants.MetadataKeys.Version);
+
+        if (raw == null) {
+            return null;
+        } else if (raw is JsonElement element) {
+            return element.GetInt32();
+        } else if (raw is int i) {
+            return i;
+        } else {
+            throw new Exception($"Version metadata has unrecognised format: {raw.GetType().FullName}");
+        }
+    }
+
+    private static string GetPhysicalCollectionName(string aliasName, int version) {
+        return $"{aliasName}_v{version}";
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Models/ExportedDocument.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Models/ExportedDocument.cs
@@ -1,0 +1,8 @@
+using Newtonsoft.Json;
+
+namespace N3O.Umbraco.Search.Typesense.Models;
+
+public class ExportedDocument {
+    [JsonProperty("id")]
+    public string Id { get; set; }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Models/PageDocument.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Models/PageDocument.cs
@@ -4,9 +4,9 @@ using Typesense;
 
 namespace N3O.Umbraco.Search.Typesense.Models;
 
-[Collection("pages")]
+[Collection("pages", 2)]
 public class PageDocument : SearchDocument {
-    [Field("timestamp", FieldType.String, true, true)]
+    [Field("timestamp", FieldType.Int64, true, true)]
     public Instant Timestamp { get; set; }
     
     [Field("content", FieldType.String, true, true)]

--- a/src/Search/N3O.Umbraco.Search.Typesense/Models/SearchDocument.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Models/SearchDocument.cs
@@ -1,4 +1,4 @@
-﻿using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Search.Typesense.Attributes;
 using System;
 using Typesense;
@@ -14,8 +14,30 @@ public abstract class SearchDocument : Value {
 
     [Field("culture", FieldType.String, false, true, facet: true)]
     public string Culture { get; set; }
-    
+
     public static string GetId(Guid contentKey, string culture) {
         return culture.HasValue() ? $"{contentKey}_{culture}" : contentKey.ToString();
+    }
+
+    public static bool TryParseId(string id, out Guid contentKey, out string culture) {
+        contentKey = Guid.Empty;
+        culture = null;
+
+        if (!id.HasValue()) {
+            return false;
+        }
+
+        var separatorIndex = id.IndexOf('_');
+        var contentKeyPart = separatorIndex < 0 ? id : id.Substring(0, separatorIndex);
+
+        if (!Guid.TryParse(contentKeyPart, out contentKey)) {
+            return false;
+        }
+
+        if (separatorIndex >= 0) {
+            culture = id.Substring(separatorIndex + 1);
+        }
+
+        return true;
     }
 }

--- a/src/Search/N3O.Umbraco.Search.Typesense/N3O.Umbraco.Search.Typesense.csproj
+++ b/src/Search/N3O.Umbraco.Search.Typesense/N3O.Umbraco.Search.Typesense.csproj
@@ -42,6 +42,6 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Typesense" Version="8.3.0" />
+        <PackageReference Include="Typesense" Version="8.5.0" />
     </ItemGroup>
 </Project>

--- a/src/Search/N3O.Umbraco.Search.Typesense/Notifications/TypesenseStartupTasks.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Notifications/TypesenseStartupTasks.cs
@@ -1,11 +1,6 @@
-﻿using N3O.Umbraco.Extensions;
-using N3O.Umbraco.Parameters;
+using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Scheduler;
-using N3O.Umbraco.Scheduler.Extensions;
 using N3O.Umbraco.Search.Typesense.Commands;
-using N3O.Umbraco.Search.Typesense.Models;
-using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Typesense;
@@ -15,6 +10,8 @@ using Umbraco.Cms.Core.Notifications;
 namespace N3O.Umbraco.Search.Typesense.Notifications;
 
 public class TypesenseStartupTasks : INotificationAsyncHandler<UmbracoApplicationStartedNotification> {
+    private const string JobName = "MigrateCollections";
+
     private readonly ITypesenseClient _typesenseClient;
     private readonly IBackgroundJob _backgroundJob;
 
@@ -23,72 +20,11 @@ public class TypesenseStartupTasks : INotificationAsyncHandler<UmbracoApplicatio
         _backgroundJob = backgroundJob;
     }
 
-    public async Task HandleAsync(UmbracoApplicationStartedNotification notification,
-                                  CancellationToken cancellationToken) {
+    public Task HandleAsync(UmbracoApplicationStartedNotification notification, CancellationToken cancellationToken) {
         if (_typesenseClient.HasValue()) {
-            foreach (var collection in TypesenseHelper.GetAllCollections()) {
-                await MigrateCollectionAsync(collection);
-            }
-        }
-    }
-
-    private async Task MigrateCollectionAsync(CollectionInfo collectionInfo) {
-        var collection = await TryGetCollectionAsync(collectionInfo.Name.Resolve());
-
-        collection = await TryDropCollectionIfOldVersionAsync(collection, collectionInfo);
-        
-        if (collection == null) {
-            await CreateCollectionAsync(collectionInfo);
-            
-            EnqueueIndexing(collectionInfo);
-        }
-    }
-
-    private async Task<CollectionResponse> TryGetCollectionAsync(string collectionName) {
-        try {
-            return await _typesenseClient.RetrieveCollection(collectionName);
-        } catch (TypesenseApiNotFoundException) {
-            return null;
-        }
-    }
-    
-    private async Task<CollectionResponse> TryDropCollectionIfOldVersionAsync(CollectionResponse collection,
-                                                                              CollectionInfo collectionInfo) {
-        if (collection != null) {
-            var metadataVersion = GetVersionFromMetadata(collection);
-
-            if (metadataVersion != collectionInfo.Version) {
-                await _typesenseClient.DeleteCollection(collectionInfo.Name.Resolve());
-
-                return null;
-            }
+            _backgroundJob.Enqueue<MigrateCollectionsCommand>(JobName);
         }
 
-        return collection;
-    }
-
-    private async Task CreateCollectionAsync(CollectionInfo collectionInfo) {
-        var collectionName = collectionInfo.Name.Resolve();
-        
-        var schema = new Schema(collectionName, collectionInfo.Fields) {
-            EnableNestedFields =  true,
-            Metadata = new Dictionary<string, object> {
-                { TypesenseConstants.MetadataKeys.Version, collectionInfo.Version }
-            }
-        };
-
-        await _typesenseClient.CreateCollection(schema);
-    }
-
-    private void EnqueueIndexing(CollectionInfo collection) {
-        foreach (var contentType in collection.ContentTypeAliases.OrEmpty()) {
-            _backgroundJob.EnqueueCommand<IndexContentsOfTypeCommand>(m => m.Add<ContentType>(contentType), contentType);
-        }
-    }
-    
-    private int? GetVersionFromMetadata(CollectionResponse collection) {
-        var collectionVersionElement = (JsonElement?) collection?.Metadata?.TryGet(TypesenseConstants.MetadataKeys.Version);
-
-        return collectionVersionElement?.GetInt32();
+        return Task.CompletedTask;
     }
 }

--- a/src/Search/N3O.Umbraco.Search.Typesense/Queries/ParameterizedTypesenseText.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Queries/ParameterizedTypesenseText.cs
@@ -1,0 +1,224 @@
+using N3O.Umbraco.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text.RegularExpressions;
+
+namespace N3O.Umbraco.Search.Typesense.Queries;
+
+public class ParameterizedTypesenseText : Value {
+    private const string AndOperator = "&&";
+    private const string NoDocumentId = "__none__";
+    private const string OrOperator = "||";
+
+    private readonly List<TypesenseParameters> _parameters;
+    private readonly Dictionary<string, int> _mergeSuffixes;
+
+    private ParameterizedTypesenseText(string text,
+                                       IEnumerable<TypesenseParameters> parameters,
+                                       IReadOnlyDictionary<string, int> mergeSuffixes) {
+        Text = text;
+        _parameters = parameters.OrEmpty().ToList();
+        _mergeSuffixes = mergeSuffixes.OrEmpty().ToDictionary(x => x.Key, x => x.Value);
+    }
+
+    public bool IsEmpty => !Text.HasValue();
+
+    public static ParameterizedTypesenseText Create(string text) {
+        return new ParameterizedTypesenseText(text, null, null);
+    }
+
+    public static ParameterizedTypesenseText Create<T>(Expression<Func<T, object>> pathExpression, string text) {
+        return Create<T, object>(pathExpression, text);
+    }
+
+    public static ParameterizedTypesenseText Create<T, TKey>(Expression<Func<T, TKey>> pathExpression, string text) {
+        return Create(TypesenseField.Get(pathExpression), text);
+    }
+
+    public static ParameterizedTypesenseText Create<T, TKey1, TKey2>(Expression<Func<T, TKey1>> pathExpression1,
+                                                                     Expression<Func<T, TKey2>> pathExpression2,
+                                                                     string text) {
+        return Create(TypesenseField.Get(pathExpression1),
+                      TypesenseField.Get(pathExpression2),
+                      text);
+    }
+
+    public static ParameterizedTypesenseText Create<T, TKey1, TKey2, TKey3>(Expression<Func<T, TKey1>> pathExpression1,
+                                                                           Expression<Func<T, TKey2>> pathExpression2,
+                                                                           Expression<Func<T, TKey3>> pathExpression3,
+                                                                           string text) {
+        return Create(TypesenseField.Get(pathExpression1),
+                      TypesenseField.Get(pathExpression2),
+                      TypesenseField.Get(pathExpression3),
+                      text);
+    }
+
+    public static ParameterizedTypesenseText Create(string path, string text) {
+        return Create([path], text);
+    }
+
+    public static ParameterizedTypesenseText Create(string path1, string path2, string text) {
+        return Create([path1, path2], text);
+    }
+
+    public static ParameterizedTypesenseText Create(string path1, string path2, string path3, string text) {
+        return Create([path1, path2, path3], text);
+    }
+
+    public static ParameterizedTypesenseText Empty() {
+        return new ParameterizedTypesenseText(null, null, null);
+    }
+
+    public static ParameterizedTypesenseText MatchesNothing() {
+        return new ParameterizedTypesenseText($"id:={NoDocumentId}", null, null);
+    }
+
+    private static ParameterizedTypesenseText Create(string[] paths, string text) {
+        if (paths.IsSingle()) {
+            text = text.Replace("þ", paths.Single());
+        } else {
+            var index = 1;
+            foreach (var path in paths) {
+                text = text.Replace($"þ{index}", path);
+
+                index++;
+            }
+        }
+
+        return Create(text);
+    }
+
+    public ParameterizedTypesenseText And(ParameterizedTypesenseText other) {
+        return Merge(other, AndOperator);
+    }
+
+    public ParameterizedTypesenseText Or(ParameterizedTypesenseText other) {
+        return Merge(other, OrOperator);
+    }
+
+    public static ParameterizedTypesenseText operator &(ParameterizedTypesenseText lhs,
+                                                        ParameterizedTypesenseText rhs) {
+        var lhsClone = lhs.Clone();
+
+        return lhsClone.Merge(rhs, AndOperator);
+    }
+
+    public static ParameterizedTypesenseText operator |(ParameterizedTypesenseText lhs,
+                                                        ParameterizedTypesenseText rhs) {
+        var lhsClone = lhs.Clone();
+
+        return lhsClone.Merge(rhs, OrOperator);
+    }
+
+    public ParameterizedTypesenseText WithParameter<T>(string name, params T[] value) {
+        if (!name.StartsWith("@")) {
+            name = "@" + name;
+        }
+
+        var convert = CachedConverter<T>.Value;
+
+        if (convert == null) {
+            throw new Exception($"Could not find a converter for parameter of type {typeof(T).FullName.Quote()}");
+        }
+
+        var convertedValues = value.Select(x => convert(x)).ToCsv();
+
+        var parameter = new TypesenseParameters(name, convertedValues);
+
+        _parameters.Add(parameter);
+
+        return this;
+    }
+
+    public override string ToString() {
+        var result = Text;
+
+        // Longest first so that @param_10 is replaced before @param_1 and @param
+        var orderedParameters = _parameters.OrderByDescending(x => x.Name.Length);
+        foreach (var parameter in orderedParameters) {
+            result = result.Replace(parameter.Name, parameter.Value);
+        }
+
+        return result;
+    }
+
+    private ParameterizedTypesenseText Merge(ParameterizedTypesenseText other, string op) {
+        var clone = other.Clone();
+
+        if (clone.IsEmpty) {
+            return this;
+        }
+
+        if (IsEmpty) {
+            Text = clone.Text;
+            _parameters.Clear();
+            _parameters.AddRange(clone.Parameters);
+        } else {
+            foreach (var parameter in _parameters) {
+                if (clone.Parameters.Any(x => x.Name == parameter.Name)) {
+                    var mergeSuffix = _mergeSuffixes.GetOrAddOrUpdate(parameter.Name,
+                                                                      () => GetSuffix(clone, parameter.Name),
+                                                                      suffix => suffix + 1);
+
+                    clone.RenameParameter(parameter.Name, mergeSuffix);
+                }
+            }
+
+            _parameters.AddRange(clone.Parameters);
+
+            Text = $"({Text}) {op} ({clone.Text})";
+        }
+
+        return this;
+    }
+
+    private ParameterizedTypesenseText Clone() {
+        var newParameters = _parameters.Select(x => new TypesenseParameters(x.Name, x.Value));
+
+        return new ParameterizedTypesenseText(Text, newParameters, _mergeSuffixes);
+    }
+
+    private void RenameParameter(string name, int suffix) {
+        var newName = $"{name}_{suffix}";
+        var parameter = Parameters.Single(x => x.Name == name);
+
+        parameter.Name = newName;
+        Text = Regex.Replace(Text,
+                             $"{name}([^a-z0-9_]|$)",
+                             m => newName + m.Groups[1].Value,
+                             RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+
+    private int GetSuffix(ParameterizedTypesenseText clause, string name) {
+        for (var suffix = 1; true; suffix++) {
+            var newName = $"{name}_{suffix}";
+
+            if (!Parameters.Any(x => x.Name.EqualsInvariant(newName)) &&
+                !clause.Parameters.Any(x => x.Name.EqualsInvariant(newName))) {
+                return suffix;
+            }
+        }
+    }
+
+    public string Text { get; private set; }
+
+    public IEnumerable<TypesenseParameters> Parameters => _parameters;
+
+    protected override IEnumerable<object> GetAtomicValues() {
+        yield return Text;
+
+        foreach (var parameter in _parameters.OrEmpty()) {
+            yield return parameter;
+        }
+
+        foreach (var mergeSuffix in _mergeSuffixes.OrEmpty()) {
+            yield return mergeSuffix;
+        }
+    }
+
+    private static class CachedConverter<T> {
+        public static readonly Func<object, string> Value = TypesenseParameterConverter.GetConverter(typeof(T));
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Queries/TypesenseParameterConverter.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Queries/TypesenseParameterConverter.cs
@@ -1,0 +1,66 @@
+using N3O.Umbraco.Lookups;
+using System;
+using System.Globalization;
+
+namespace N3O.Umbraco.Search.Typesense.Queries;
+
+public static class TypesenseParameterConverter {
+    public static Func<object, string> GetConverter(Type parameterType) {
+        var documentConverter = TypesenseConverterRegistry.GetConverter(parameterType);
+
+        if (documentConverter != null) {
+            var convert = GetScalarConverter(documentConverter.UnderlyingTypesenseType);
+
+            return convert == null ? null : v => convert(documentConverter.ToTypesenseValue(v));
+        } else if (typeof(ILookup).IsAssignableFrom(parameterType)) {
+            return v => Backtick(((ILookup) v)?.Id);
+        } else {
+            return GetScalarConverter(parameterType);
+        }
+    }
+
+    private static string Backtick(string value) {
+        return $"`{value?.Replace("`", "\\`")}`";
+    }
+
+    // The scalar shapes Typesense accepts as a filter_by literal, covering String, Bool, Int32, Int64 and
+    // Float and their array forms. Object fields are filtered by sub-field path and GeoPoint by its own
+    // compound syntax, so neither is a literal and both resolve to no converter.
+    private static Func<object, string> GetScalarConverter(Type type) {
+        var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (underlyingType == typeof(string)) {
+            return v => Backtick((string) v);
+        } else if (underlyingType == typeof(bool)) {
+            return v => v == null ? null : (bool) v ? "true" : "false";
+        } else if (underlyingType == typeof(Guid) ||
+                   underlyingType == typeof(TimeSpan) ||
+                   underlyingType == typeof(char)) {
+            return v => v == null ? null : Backtick(Convert.ToString(v, CultureInfo.InvariantCulture));
+        } else if (underlyingType.IsEnum) {
+            var integralType = Enum.GetUnderlyingType(underlyingType);
+
+            return v => v == null
+                            ? null
+                            : Convert.ToString(Convert.ChangeType(v, integralType), CultureInfo.InvariantCulture);
+        } else if (IsNumeric(underlyingType)) {
+            return v => v == null ? null : Convert.ToString(v, CultureInfo.InvariantCulture);
+        } else {
+            return null;
+        }
+    }
+
+    private static bool IsNumeric(Type type) {
+        return type == typeof(int) ||
+               type == typeof(long) ||
+               type == typeof(decimal) ||
+               type == typeof(double) ||
+               type == typeof(float) ||
+               type == typeof(short) ||
+               type == typeof(byte) ||
+               type == typeof(sbyte) ||
+               type == typeof(ushort) ||
+               type == typeof(uint) ||
+               type == typeof(ulong);
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Queries/TypesenseParameters.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Queries/TypesenseParameters.cs
@@ -1,0 +1,11 @@
+namespace N3O.Umbraco.Search.Typesense.Queries;
+
+public class TypesenseParameters {
+    public TypesenseParameters(string name, string value) {
+        Name = name;
+        Value = value;
+    }
+
+    public string Name { get; set; }
+    public string Value { get; set; }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Bool.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Bool.cs
@@ -1,0 +1,7 @@
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public abstract class BoolTypesenseConverter<T> : TypesenseConverter<T, bool?> {
+    public override FieldType FieldType => FieldType.Bool;
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.DateTimeOffset.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.DateTimeOffset.cs
@@ -1,0 +1,20 @@
+using N3O.Umbraco.Extensions;
+using System;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public class DateTimeOffsetTypesenseConverter : Int64TypesenseConverter<DateTimeOffset?> {
+    public override bool CanConvert(Type type) {
+        return type.IsOfTypeOrNullableType<DateTimeOffset>();
+    }
+
+    protected override DateTimeOffset? FromTypesense(long? value) {
+        return value.HasValue
+                   ? DateTimeOffset.FromUnixTimeMilliseconds(value.GetValueOrThrow())
+                   : null;
+    }
+
+    protected override long? ToTypesense(DateTimeOffset? value) {
+        return value?.ToUnixTimeMilliseconds();
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Float.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Float.cs
@@ -1,0 +1,7 @@
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public abstract class FloatTypesenseConverter<T> : TypesenseConverter<T, decimal?> {
+    public override FieldType FieldType => FieldType.Float;
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.I.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.I.cs
@@ -1,0 +1,14 @@
+using System;
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public interface ITypesenseConverter {
+    bool CanConvert(Type type);
+
+    object FromTypesenseValue(object value);
+    object ToTypesenseValue(object value);
+
+    Type UnderlyingTypesenseType { get; }
+    FieldType FieldType { get; }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Instant.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Instant.cs
@@ -1,0 +1,21 @@
+using N3O.Umbraco.Extensions;
+using NodaTime;
+using System;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public class InstantTypesenseConverter : Int64TypesenseConverter<Instant?> {
+    public override bool CanConvert(Type type) {
+        return type.IsOfTypeOrNullableType<Instant>();
+    }
+
+    protected override Instant? FromTypesense(long? value) {
+        return value.HasValue
+                   ? Instant.FromUnixTimeMilliseconds(value.GetValueOrThrow())
+                   : null;
+    }
+
+    protected override long? ToTypesense(Instant? value) {
+        return value?.ToUnixTimeMilliseconds();
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Int32.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Int32.cs
@@ -1,0 +1,7 @@
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public abstract class Int32TypesenseConverter<T> : TypesenseConverter<T, int?> {
+    public override FieldType FieldType => FieldType.Int32;
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Int64.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Int64.cs
@@ -1,0 +1,7 @@
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public abstract class Int64TypesenseConverter<T> : TypesenseConverter<T, long?> {
+    public override FieldType FieldType => FieldType.Int64;
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.LocalDate.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.LocalDate.cs
@@ -1,0 +1,21 @@
+using N3O.Umbraco.Extensions;
+using NodaTime;
+using System;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public class LocalDateTypesenseConverter : Int64TypesenseConverter<LocalDate?> {
+    public override bool CanConvert(Type type) {
+        return type.IsOfTypeOrNullableType<LocalDate>();
+    }
+
+    protected override LocalDate? FromTypesense(long? value) {
+        return value.HasValue
+                   ? Instant.FromUnixTimeMilliseconds(value.GetValueOrThrow()).InUtc().Date
+                   : null;
+    }
+
+    protected override long? ToTypesense(LocalDate? value) {
+        return value?.AtMidnight().InUtc().ToInstant().ToUnixTimeMilliseconds();
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.LocalDateTime.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.LocalDateTime.cs
@@ -1,0 +1,21 @@
+using N3O.Umbraco.Extensions;
+using NodaTime;
+using System;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public class LocalDateTimeTypesenseConverter : Int64TypesenseConverter<LocalDateTime?> {
+    public override bool CanConvert(Type type) {
+        return type.IsOfTypeOrNullableType<LocalDateTime>();
+    }
+
+    protected override LocalDateTime? FromTypesense(long? value) {
+        return value.HasValue
+                   ? Instant.FromUnixTimeMilliseconds(value.GetValueOrThrow()).InUtc().LocalDateTime
+                   : null;
+    }
+
+    protected override long? ToTypesense(LocalDateTime? value) {
+        return value?.InUtc().ToInstant().ToUnixTimeMilliseconds();
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.LocalTime.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.LocalTime.cs
@@ -1,0 +1,21 @@
+using N3O.Umbraco.Extensions;
+using NodaTime;
+using System;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public class LocalTimeTypesenseConverter : Int64TypesenseConverter<LocalTime?> {
+    public override bool CanConvert(Type type) {
+        return type.IsOfTypeOrNullableType<LocalTime>();
+    }
+
+    protected override LocalTime? FromTypesense(long? value) {
+        return value.HasValue
+                   ? LocalTime.FromNanosecondsSinceMidnight(value.GetValueOrThrow())
+                   : null;
+    }
+
+    protected override long? ToTypesense(LocalTime? value) {
+        return value?.NanosecondOfDay;
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Object.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Object.cs
@@ -1,0 +1,7 @@
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public abstract class ObjectTypesenseConverter<T> : TypesenseConverter<T, object> {
+    public override FieldType FieldType => FieldType.Object;
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.String.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.String.cs
@@ -1,0 +1,7 @@
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public abstract class StringTypesenseConverter<T> : TypesenseConverter<T, string> {
+    public override FieldType FieldType => FieldType.String;
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Uri.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.Uri.cs
@@ -1,0 +1,18 @@
+using N3O.Umbraco.Extensions;
+using System;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public class UriTypesenseConverter : StringTypesenseConverter<Uri> {
+    public override bool CanConvert(Type type) {
+        return type == typeof(Uri);
+    }
+
+    protected override Uri FromTypesense(string value) {
+        return value.HasValue() ? new Uri(value) : null;
+    }
+
+    protected override string ToTypesense(Uri value) {
+        return value?.OriginalString;
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/Converters/TypesenseConverter.cs
@@ -1,0 +1,37 @@
+using System;
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public abstract class TypesenseConverter<T, U> : ITypesenseConverter {
+    public abstract bool CanConvert(Type type);
+
+    public object FromTypesenseValue(object value) {
+        if (value == null) {
+            return FromTypesense(default(U));
+        }
+
+        if (value is U typed) {
+            return FromTypesense(typed);
+        }
+
+        var targetType = Nullable.GetUnderlyingType(typeof(U)) ?? typeof(U);
+        var converted = (U) Convert.ChangeType(value, targetType);
+
+        return FromTypesense(converted);
+    }
+
+    public object ToTypesenseValue(object value) {
+        if (value == null) {
+            return null;
+        } else {
+            return ToTypesense((T) value);
+        }
+    }
+
+    protected abstract T FromTypesense(U value);
+    protected abstract U ToTypesense(T value);
+
+    public Type UnderlyingTypesenseType => typeof(U);
+    public abstract FieldType FieldType { get; }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/NestedFieldExpander.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/NestedFieldExpander.cs
@@ -1,0 +1,311 @@
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Lookups;
+using N3O.Umbraco.Search.Typesense.Attributes;
+using N3O.Umbraco.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public static class NestedFieldExpander {
+    private static readonly TypesenseJsonContractResolver ContractResolver = new();
+    private static readonly Lazy<IReadOnlyList<JsonConverter>> JsonConverters = new(LoadJsonConverters);
+
+    public static bool ShouldExpand(FieldAttribute attribute) {
+        return attribute.Index && (attribute.Type == FieldType.Object || attribute.Type == FieldType.ObjectArray);
+    }
+
+    public static IReadOnlyList<Field> Expand(Type documentType, PropertyInfo property, FieldAttribute attribute) {
+        ValidateOptions(documentType, attribute);
+
+        var rootProperty = GetRootProperty(documentType, property, attribute);
+        var objectType = GetObjectType(documentType, property, attribute);
+        var isArray = attribute.Type == FieldType.ObjectArray;
+        var fields = new List<Field>();
+        var ancestry = new List<Type>();
+
+        if (HasMemberConverter(rootProperty)) {
+            throw new Exception($"Field {attribute.Name.Quote()} on {documentType.GetFriendlyName()} is declared as " +
+                                $"{attribute.Type} but {property.Name} has its own JsonConverter, so the shape it " +
+                                "writes cannot be expanded into nested fields");
+        } else if (!IsExpandableType(objectType)) {
+            throw new Exception($"Field {attribute.Name.Quote()} on {documentType.GetFriendlyName()} is declared as " +
+                                $"{attribute.Type} but {objectType.GetFriendlyName()} cannot be expanded into " +
+                                "nested fields");
+        }
+
+        // NullValueHandling omits a null object, and Typesense stops indexing a document missing a non-optional field
+        var isRequired = attribute.Required && !isArray && IsAlwaysWritten(rootProperty);
+
+        AddFieldsForType(objectType, attribute.Name, isArray, isRequired, ancestry, fields);
+
+        ValidateFields(documentType, attribute.Name, fields);
+
+        return fields;
+    }
+
+    private static void ValidateOptions(Type documentType, FieldAttribute attribute) {
+        if (attribute.Facet ||
+            attribute.Sort ||
+            attribute.Infix ||
+            attribute.Locale.HasValue() ||
+            attribute.NumberOfDimensions != 0) {
+            throw new Exception($"Field {attribute.Name.Quote()} on {documentType.GetFriendlyName()} is expanded " +
+                                "into its nested fields, so facet, sort, infix, locale and number of dimensions " +
+                                "cannot be set on it");
+        }
+    }
+
+    private static JsonProperty GetRootProperty(Type documentType, PropertyInfo property, FieldAttribute attribute) {
+        var rootProperty = GetSerializedProperties(documentType).FirstOrDefault(x => x.UnderlyingName == property.Name);
+
+        if (rootProperty == null) {
+            throw new Exception($"Field {attribute.Name.Quote()} on {documentType.GetFriendlyName()} is declared on " +
+                                $"{property.Name}, which the serializer does not write");
+        }
+
+        return rootProperty;
+    }
+
+    private static Type GetObjectType(Type documentType, PropertyInfo property, FieldAttribute attribute) {
+        var propertyType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+
+        if (IsDictionaryType(propertyType)) {
+            throw new Exception($"Field {attribute.Name.Quote()} on {documentType.GetFriendlyName()} is declared as " +
+                                $"{attribute.Type} but {property.Name} is a dictionary, whose keys are data and so " +
+                                "cannot be declared as fields");
+        }
+
+        var arrayContract = GetArrayContract(propertyType);
+
+        if (attribute.Type == FieldType.ObjectArray) {
+            if (arrayContract == null) {
+                throw new Exception($"Field {attribute.Name.Quote()} on {documentType.GetFriendlyName()} is declared " +
+                                    $"as {attribute.Type} but {property.Name} is not a collection");
+            } else if (arrayContract.CollectionItemType == null) {
+                throw new Exception($"Field {attribute.Name.Quote()} on {documentType.GetFriendlyName()} is declared " +
+                                    $"as {attribute.Type} but the element type of {property.Name} cannot be " +
+                                    "determined");
+            }
+
+            return arrayContract.CollectionItemType;
+        } else if (arrayContract != null) {
+            throw new Exception($"Field {attribute.Name.Quote()} on {documentType.GetFriendlyName()} is declared as " +
+                                $"{attribute.Type} but {property.Name} is a collection");
+        } else {
+            return propertyType;
+        }
+    }
+
+    private static void ValidateFields(Type documentType, string name, IReadOnlyList<Field> fields) {
+        if (fields.None()) {
+            throw new Exception($"Field {name.Quote()} on {documentType.GetFriendlyName()} expanded to no nested " +
+                                "fields because none of its properties have a Typesense field type");
+        }
+    }
+
+    private static void AddFieldsForType(Type type,
+                                         string path,
+                                         bool isArray,
+                                         bool isRequired,
+                                         List<Type> ancestry,
+                                         List<Field> fields) {
+        if (ancestry.Contains(type)) {
+            return;
+        } else if (ancestry.Count == MaxDepth) {
+            throw new Exception($"Field {path.Quote()} is nested more than {MaxDepth} levels deep, which means its " +
+                                "type expands without terminating");
+        }
+
+        ancestry.Add(type);
+
+        foreach (var property in GetSerializedProperties(type)) {
+            var propertyPath = $"{path}{TypesenseField.PathSeparator}{property.PropertyName}";
+
+            AddFieldsForProperty(property, propertyPath, isArray, isRequired, ancestry, fields);
+        }
+
+        ancestry.RemoveAt(ancestry.Count - 1);
+    }
+
+    private static void AddFieldsForProperty(JsonProperty property,
+                                             string path,
+                                             bool isArray,
+                                             bool isRequired,
+                                             List<Type> ancestry,
+                                             List<Field> fields) {
+        var propertyType = property.PropertyType;
+        var underlyingType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+        var isRequiredHere = isRequired && IsAlwaysWritten(property);
+
+        if (HasMemberConverter(property)) {
+            return;
+        } else if (GetFieldType(propertyType) is FieldType fieldType) {
+            fields.Add(CreateField(path, fieldType, isArray, isRequiredHere));
+        } else if (typeof(JToken).IsAssignableFrom(underlyingType) || IsDictionaryType(underlyingType)) {
+            return;
+        } else if (GetArrayContract(underlyingType) is JsonArrayContract arrayContract) {
+            AddFieldsForCollection(arrayContract, path, ancestry, fields);
+        } else if (IsExpandableType(underlyingType)) {
+            AddFieldsForType(underlyingType, path, isArray, isRequiredHere, ancestry, fields);
+        }
+    }
+
+    private static void AddFieldsForCollection(JsonArrayContract contract,
+                                               string path,
+                                               List<Type> ancestry,
+                                               List<Field> fields) {
+        var elementType = contract.CollectionItemType;
+
+        if (elementType == null) {
+            return;
+        }
+
+        var underlyingElementType = Nullable.GetUnderlyingType(elementType) ?? elementType;
+
+        if (TypesenseConverterRegistry.GetConverter(elementType) != null) {
+            return;
+        } else if (underlyingElementType == typeof(byte)) {
+            return;
+        } else if (GetFieldType(elementType) is FieldType elementFieldType) {
+            fields.Add(CreateField(path, elementFieldType, true, false));
+        } else if (IsExpandableType(underlyingElementType)) {
+            AddFieldsForType(underlyingElementType, path, true, false, ancestry, fields);
+        }
+    }
+
+    private static IReadOnlyList<JsonProperty> GetSerializedProperties(Type type) {
+        return GetContract(type).Properties
+                                .Where(x => !x.Ignored && x.Readable)
+                                .ToList();
+    }
+
+    private static JsonObjectContract GetContract(Type type) {
+        return ContractResolver.ResolveContract(type) as JsonObjectContract;
+    }
+
+    private static JsonArrayContract GetArrayContract(Type type) {
+        return ContractResolver.ResolveContract(type) as JsonArrayContract;
+    }
+
+    private static FieldType? GetFieldType(Type type) {
+        var converter = TypesenseConverterRegistry.GetConverter(type);
+
+        if (converter != null) {
+            return GetScalarFieldType(converter.UnderlyingTypesenseType);
+        } else if (IsIdLookup(Nullable.GetUnderlyingType(type) ?? type)) {
+            return FieldType.String;
+        } else {
+            return GetScalarFieldType(type);
+        }
+    }
+
+    private static bool IsIdLookup(Type type) {
+        return !type.IsInterface && type.IsLookup() && !IsBaseLookup(type);
+    }
+
+    private static bool IsBaseLookup(Type type) {
+        return type.IsAnyOf(typeof(Lookup), typeof(NamedLookup));
+    }
+
+    private static bool IsKnownAtCompileTime(Type type) {
+        return !type.IsInterface && !type.IsAbstract;
+    }
+
+    private static FieldType? GetScalarFieldType(Type type) {
+        var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+        var typeCode = Type.GetTypeCode(underlyingType);
+
+        if (underlyingType.IsEnum && HasJsonConverterFor(underlyingType)) {
+            return null;
+        } else if (underlyingType == typeof(Guid) || underlyingType == typeof(TimeSpan)) {
+            return FieldType.String;
+        } else if (typeCode == TypeCode.Boolean) {
+            return FieldType.Bool;
+        } else if (typeCode.IsAnyOf(TypeCode.Byte, TypeCode.Int16, TypeCode.Int32, TypeCode.SByte, TypeCode.UInt16)) {
+            return FieldType.Int32;
+        } else if (typeCode.IsAnyOf(TypeCode.Int64, TypeCode.UInt32, TypeCode.UInt64)) {
+            return FieldType.Int64;
+        } else if (typeCode.IsAnyOf(TypeCode.Decimal, TypeCode.Double, TypeCode.Single)) {
+            return FieldType.Float;
+        } else if (typeCode.IsAnyOf(TypeCode.Char, TypeCode.String)) {
+            return FieldType.String;
+        } else {
+            return null;
+        }
+    }
+
+    private static bool IsExpandableType(Type type) {
+        return !type.IsEnum &&
+               IsKnownAtCompileTime(type) &&
+               !IsBaseLookup(type) &&
+               OurAssemblies.IsOurAssembly(type.Assembly) &&
+               TypesenseConverterRegistry.GetConverter(type) == null &&
+               !HasJsonConverterFor(type) &&
+               GetContract(type) != null;
+    }
+
+    private static bool HasJsonConverterFor(Type type) {
+        return type.HasAttribute<JsonConverterAttribute>() ||
+               JsonConverters.Value.Any(x => x.CanWrite && x.CanConvert(type));
+    }
+
+    private static bool HasMemberConverter(JsonProperty property) {
+        return property.ItemConverter != null ||
+               (property.Converter != null && !(property.Converter is TypesenseDispatchJsonConverter));
+    }
+
+    private static bool IsDictionaryType(Type type) {
+        return ContractResolver.ResolveContract(type) is JsonDictionaryContract;
+    }
+
+    // Registration runs before the container exists, so only parameterless converters can be constructed here
+    private static IReadOnlyList<JsonConverter> LoadJsonConverters() {
+        return OurAssemblies.GetTypes(x => x.IsConcreteClass() &&
+                                           x.IsSubclassOfType(typeof(JsonConverter)) &&
+                                           x.HasParameterlessConstructor())
+                            .Select(x => (JsonConverter) Activator.CreateInstance(x))
+                            .ToList();
+    }
+
+    private static bool IsAlwaysWritten(JsonProperty property) {
+        return property.ShouldSerialize == null &&
+               property.GetIsSpecified == null &&
+               !property.DefaultValueHandling.GetValueOrDefault().HasFlag(DefaultValueHandling.Ignore) &&
+               IsAlwaysWritten(property.PropertyType);
+    }
+
+    private static bool IsAlwaysWritten(Type type) {
+        return type.IsValueType && Nullable.GetUnderlyingType(type) == null;
+    }
+
+    private static Field CreateField(string path, FieldType fieldType, bool isArray, bool isRequired) {
+        var type = isArray ? ToArrayFieldType(path, fieldType) : fieldType;
+
+        return new Field(path, type, false, !isRequired, true);
+    }
+
+    private static FieldType ToArrayFieldType(string path, FieldType fieldType) {
+        if (fieldType == FieldType.Bool) {
+            return FieldType.BoolArray;
+        } else if (fieldType == FieldType.Float) {
+            return FieldType.FloatArray;
+        } else if (fieldType == FieldType.Int32) {
+            return FieldType.Int32Array;
+        } else if (fieldType == FieldType.Int64) {
+            return FieldType.Int64Array;
+        } else if (fieldType == FieldType.String) {
+            return FieldType.StringArray;
+        } else {
+            throw new Exception($"Cannot index {path.Quote()} because field type {fieldType} has no array form");
+        }
+    }
+
+    private const int MaxDepth = 16;
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.I.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.I.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using N3O.Umbraco.Search.Typesense.Models;
+using System;
 using System.Threading.Tasks;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
@@ -7,6 +8,7 @@ namespace N3O.Umbraco.Search.Typesense;
 public interface ISearchIndexer {
     bool CanIndex(IPublishedContent content);
     bool CanIndex(string contentTypeAlias);
+    bool IsIndexerFor(CollectionName collectionName);
     Task DeleteAsync(Guid contentKey);
-    Task IndexAsync(IPublishedContent content, string culture = null);
+    Task IndexAsync(IPublishedContent content, string culture = null, string targetCollectionName = null);
 }

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/SearchIndexer.cs
@@ -1,4 +1,4 @@
-﻿using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Search.Typesense.Models;
 using System;
 using System.Threading.Tasks;
@@ -23,7 +23,7 @@ public abstract class SearchIndexer<TContent, TDocument> : ISearchIndexer
         _searchDocumentBuilder = searchDocumentBuilder;
         _variationContextAccessor = variationContextAccessor;
     }
-    
+
     public bool CanIndex(IPublishedContent content) {
         return content is TContent;
     }
@@ -32,6 +32,10 @@ public abstract class SearchIndexer<TContent, TDocument> : ISearchIndexer
         var collectionInfo = TypesenseHelper.GetCollection<TDocument>();
 
         return collectionInfo.ContentTypeAliases.OrEmpty().InvariantContains(contentTypeAlias);
+    }
+
+    public bool IsIndexerFor(CollectionName collectionName) {
+        return TypesenseHelper.GetCollection<TDocument>().Name == collectionName;
     }
 
     public async Task DeleteAsync(Guid contentKey) {
@@ -44,7 +48,7 @@ public abstract class SearchIndexer<TContent, TDocument> : ISearchIndexer
         await _typesenseClient.DeleteDocuments(collectionInfo.Name.Resolve(), $"content_key:=`{contentKey}`");
     }
 
-    public async Task IndexAsync(IPublishedContent content, string culture = null) {
+    public async Task IndexAsync(IPublishedContent content, string culture = null, string targetCollectionName = null) {
         if (!_typesenseClient.HasValue()) {
             return;
         }
@@ -63,8 +67,9 @@ public abstract class SearchIndexer<TContent, TDocument> : ISearchIndexer
 
         var document = _searchDocumentBuilder.Build();
         var collectionInfo = TypesenseHelper.GetCollection<TDocument>();
-        
-        await _typesenseClient.UpsertDocument(collectionInfo.Name.Resolve(), document);
+        var collectionName = targetCollectionName ?? collectionInfo.Name.Resolve();
+
+        await _typesenseClient.UpsertDocument(collectionName, document);
     }
 
     protected abstract Task ProcessContentAsync(ISearchDocumentBuilder<TDocument> builder, TContent content);

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseClauseBuilder.I.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseClauseBuilder.I.cs
@@ -1,0 +1,24 @@
+using N3O.Umbraco.Search.Typesense.Models;
+using N3O.Umbraco.Search.Typesense.Queries;
+using System;
+using System.Linq.Expressions;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public interface ITypesenseClauseBuilder<T> where T : SearchDocument {
+    ITypesenseClauseBuilder<T> And<TKey>(Expression<Func<T, TKey>> pathExpression,
+                                         string expression,
+                                         params Action<ParameterizedTypesenseText>[] filterActions);
+
+    ITypesenseClauseBuilder<T> Or<TKey>(Expression<Func<T, TKey>> pathExpression,
+                                        string expression,
+                                        params Action<ParameterizedTypesenseText>[] filterActions);
+
+    ITypesenseClauseBuilder<T> And(Action<ITypesenseClauseBuilder<T>> buildClause);
+
+    ITypesenseClauseBuilder<T> Or(Action<ITypesenseClauseBuilder<T>> buildClause);
+
+    ITypesenseClauseBuilder<T> And(ParameterizedTypesenseText other);
+
+    ITypesenseClauseBuilder<T> Or(ParameterizedTypesenseText other);
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseClauseBuilder.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseClauseBuilder.cs
@@ -1,0 +1,74 @@
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Search.Typesense.Models;
+using N3O.Umbraco.Search.Typesense.Queries;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public class TypesenseClauseBuilder<T> : ITypesenseClauseBuilder<T> where T : SearchDocument {
+    private readonly ParameterizedTypesenseText _clause = ParameterizedTypesenseText.Empty();
+
+    public ITypesenseClauseBuilder<T> And<TKey>(Expression<Func<T, TKey>> pathExpression,
+                                                string expression,
+                                                params Action<ParameterizedTypesenseText>[] filterActions) {
+        _clause.And(BuildLeaf(pathExpression, expression, filterActions));
+
+        return this;
+    }
+
+    public ITypesenseClauseBuilder<T> Or<TKey>(Expression<Func<T, TKey>> pathExpression,
+                                               string expression,
+                                               params Action<ParameterizedTypesenseText>[] filterActions) {
+        _clause.Or(BuildLeaf(pathExpression, expression, filterActions));
+
+        return this;
+    }
+
+    public ITypesenseClauseBuilder<T> And(Action<ITypesenseClauseBuilder<T>> buildClause) {
+        _clause.And(BuildNested(buildClause));
+
+        return this;
+    }
+
+    public ITypesenseClauseBuilder<T> Or(Action<ITypesenseClauseBuilder<T>> buildClause) {
+        _clause.Or(BuildNested(buildClause));
+
+        return this;
+    }
+
+    public ITypesenseClauseBuilder<T> And(ParameterizedTypesenseText other) {
+        _clause.And(other);
+
+        return this;
+    }
+
+    public ITypesenseClauseBuilder<T> Or(ParameterizedTypesenseText other) {
+        _clause.Or(other);
+
+        return this;
+    }
+
+    public ParameterizedTypesenseText Build() {
+        return _clause;
+    }
+
+    private static ParameterizedTypesenseText BuildLeaf<TKey>(Expression<Func<T, TKey>> pathExpression,
+                                                              string expression,
+                                                              IEnumerable<Action<ParameterizedTypesenseText>> filterActions) {
+        var leaf = ParameterizedTypesenseText.Create(pathExpression, expression);
+
+        filterActions.Do(e => e?.Invoke(leaf));
+
+        return leaf;
+    }
+
+    private static ParameterizedTypesenseText BuildNested(Action<ITypesenseClauseBuilder<T>> buildClause) {
+        var inner = new TypesenseClauseBuilder<T>();
+
+        buildClause(inner);
+
+        return inner.Build();
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseConverterRegistry.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseConverterRegistry.cs
@@ -1,0 +1,27 @@
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public static class TypesenseConverterRegistry {
+    private static readonly Lazy<IReadOnlyList<ITypesenseConverter>> All = new(LoadAll);
+
+    public static ITypesenseConverter GetConverter(Type type) {
+        return All.Value.FirstOrDefault(x => x.CanConvert(type));
+    }
+
+    public static bool HasConverterFor(Type type) {
+        return All.Value.Any(x => x.CanConvert(type));
+    }
+
+    private static IReadOnlyList<ITypesenseConverter> LoadAll() {
+        return OurAssemblies.GetTypes(x => x.IsConcreteClass() &&
+                                           x.ImplementsInterface<ITypesenseConverter>() &&
+                                           x.HasParameterlessConstructor())
+                            .Select(x => (ITypesenseConverter) Activator.CreateInstance(x))
+                            .ToList();
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseDispatchJsonConverter.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseDispatchJsonConverter.cs
@@ -1,0 +1,50 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public class TypesenseDispatchJsonConverter : JsonConverter {
+    public static readonly TypesenseDispatchJsonConverter Instance = new();
+
+    private TypesenseDispatchJsonConverter() { }
+
+    public override bool CanConvert(Type objectType) {
+        return TypesenseConverterRegistry.HasConverterFor(objectType);
+    }
+
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) {
+        if (value == null) {
+            writer.WriteNull();
+
+            return;
+        }
+
+        var converter = TypesenseConverterRegistry.GetConverter(value.GetType());
+        var typesenseValue = converter.ToTypesenseValue(value);
+
+        if (typesenseValue == null) {
+            writer.WriteNull();
+        } else {
+            serializer.Serialize(writer, typesenseValue);
+        }
+    }
+
+    public override object ReadJson(JsonReader reader,
+                                    Type objectType,
+                                    object existingValue,
+                                    JsonSerializer serializer) {
+        if (reader.TokenType == JsonToken.Null) {
+            return null;
+        }
+
+        var converter = TypesenseConverterRegistry.GetConverter(objectType);
+        var token = JToken.Load(reader);
+
+        var typesenseValue = token.Type == JTokenType.Null
+                                 ? null
+                                 : token.ToObject(converter.UnderlyingTypesenseType, serializer);
+
+        return converter.FromTypesenseValue(typesenseValue);
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseField.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseField.cs
@@ -1,0 +1,60 @@
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Search.Typesense.Attributes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public static class TypesenseField {
+    private static readonly NamingStrategy CamelCase = new CamelCaseNamingStrategy {
+        ProcessDictionaryKeys = false
+    };
+
+    public static string Get<T, TField>(Expression<Func<T, TField>> pathExpression) {
+        var pathComponents = new List<string>();
+        MemberExpression memberExpression;
+
+        switch (pathExpression.Body.NodeType) {
+            case ExpressionType.Convert:
+            case ExpressionType.ConvertChecked:
+                memberExpression = (pathExpression.Body as UnaryExpression)?.Operand as MemberExpression;
+                break;
+
+            default:
+                memberExpression = pathExpression.Body as MemberExpression;
+                break;
+        }
+
+        while (memberExpression != null) {
+            var propertyName = ToSearchFieldName(memberExpression.Member);
+
+            pathComponents.Insert(0, propertyName);
+
+            memberExpression = memberExpression.Expression as MemberExpression;
+        }
+
+        return string.Join(PathSeparator, pathComponents);
+    }
+
+    public static string ToSearchFieldName(MemberInfo memberInfo) {
+        var propertyInfo = memberInfo as PropertyInfo;
+
+        var fieldAttribute = propertyInfo?.GetCustomAttribute<FieldAttribute>();
+        if (fieldAttribute != null) {
+            return fieldAttribute.Name;
+        }
+
+        var jsonProperty = propertyInfo?.GetCustomAttribute<JsonPropertyAttribute>();
+        if (jsonProperty?.PropertyName.HasValue() == true) {
+            return jsonProperty.PropertyName;
+        }
+
+        return CamelCase.GetPropertyName(memberInfo.Name, hasSpecifiedName: false);
+    }
+
+    public const char PathSeparator = '.';
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseHelper.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseHelper.cs
@@ -1,7 +1,8 @@
-﻿using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Extensions;
 using N3O.Umbraco.Search.Typesense.Attributes;
 using N3O.Umbraco.Search.Typesense.Models;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -10,7 +11,7 @@ using Typesense;
 namespace N3O.Umbraco.Search.Typesense;
 
 public static class TypesenseHelper {
-    private static readonly Dictionary<Type, CollectionInfo> CollectionsMap = new();
+    private static readonly ConcurrentDictionary<Type, CollectionInfo> CollectionsMap = new();
 
     public static IReadOnlyList<CollectionInfo> GetAllCollections() => CollectionsMap.Values.ToList();
     
@@ -32,28 +33,62 @@ public static class TypesenseHelper {
         CollectionsMap[typeof(TDocument)] = collectionInfo;
     }
 
-    private static IEnumerable<Field> GetFields<TDocument>() {
+    private static IReadOnlyList<Field> GetFields<TDocument>() {
         var fields = new List<Field>();
-        
+
+        AddFields<TDocument>(fields);
+        AddIndexFields<TDocument>(fields);
+
+        ValidateNoDuplicates<TDocument>(fields);
+
+        return fields;
+    }
+
+    private static void AddFields<TDocument>(List<Field> fields) {
+        var documentType = typeof(TDocument);
+
+        foreach (var property in documentType.GetProperties()) {
+            var attribute = property.GetCustomAttribute<FieldAttribute>();
+
+            if (attribute == null) {
+                continue;
+            } else if (NestedFieldExpander.ShouldExpand(attribute)) {
+                fields.AddRange(NestedFieldExpander.Expand(documentType, property, attribute));
+            } else {
+                var field = new Field(attribute.Name,
+                                      attribute.Type,
+                                      attribute.Facet,
+                                      !attribute.Required,
+                                      attribute.Index,
+                                      attribute.Sort,
+                                      attribute.Infix,
+                                      attribute.Locale,
+                                      attribute.NumberOfDimensions);
+
+                fields.Add(field);
+            }
+        }
+    }
+
+    private static void AddIndexFields<TDocument>(List<Field> fields) {
         var attributes = typeof(TDocument).GetProperties()
-                                          .Select(x => x.GetCustomAttribute<FieldAttribute>())
+                                          .Select(x => x.GetCustomAttribute<IndexAttribute>())
                                           .ExceptNull()
                                           .ToList();
 
         foreach (var attribute in attributes) {
-            var field = new Field(attribute.Name,
-                                  attribute.Type,
-                                  attribute.Facet,
-                                  !attribute.Required,
-                                  attribute.Index,
-                                  attribute.Sort,
-                                  attribute.Infix,
-                                  attribute.Locale,
-                                  attribute.NumberOfDimensions);
+            var field = new Field(attribute.Name, attribute.Type, false, !attribute.Required, true);
 
             fields.Add(field);
         }
+    }
 
-        return fields;
+    private static void ValidateNoDuplicates<TDocument>(IReadOnlyList<Field> fields) {
+        var duplicate = fields.GroupBy(x => x.Name).FirstOrDefault(x => x.Count() > 1);
+
+        if (duplicate != null) {
+            throw new Exception($"Type {typeof(TDocument).GetFriendlyName()} declares more than one Typesense field " +
+                                $"named {duplicate.Key.Quote()}");
+        }
     }
 }

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseHelper.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseHelper.cs
@@ -72,8 +72,7 @@ public static class TypesenseHelper {
 
     private static void AddIndexFields<TDocument>(List<Field> fields) {
         var attributes = typeof(TDocument).GetProperties()
-                                          .Select(x => x.GetCustomAttribute<IndexAttribute>())
-                                          .ExceptNull()
+                                          .SelectMany(x => x.GetCustomAttributes<IndexAttribute>())
                                           .ToList();
 
         foreach (var attribute in attributes) {

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseJsonContractResolver.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseJsonContractResolver.cs
@@ -1,5 +1,5 @@
-﻿using N3O.Umbraco.Json;
-using N3O.Umbraco.Search.Typesense.Attributes;
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Json;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using System.Reflection;
@@ -9,11 +9,21 @@ namespace N3O.Umbraco.Search.Typesense;
 public class TypesenseJsonContractResolver : JsonContractResolver {
     protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization) {
         var jsonProperty = base.CreateProperty(member, memberSerialization);
-        
-        var attribute = (member as PropertyInfo)?.GetCustomAttribute<FieldAttribute>();
 
-        if (attribute != null) {
-            jsonProperty.PropertyName = attribute.Name;
+        var typesenseFieldName = TypesenseField.ToSearchFieldName(member);
+
+        if (typesenseFieldName.HasValue()) {
+            jsonProperty.PropertyName = typesenseFieldName;
+        }
+
+        var converter = TypesenseConverterRegistry.GetConverter(jsonProperty.PropertyType);
+
+        if (converter != null) {
+            var valueProvider = jsonProperty.ValueProvider;
+
+            // A converter can produce null from a non-null value, which NullValueHandling cannot see
+            jsonProperty.Converter = TypesenseDispatchJsonConverter.Instance;
+            jsonProperty.ShouldSerialize = instance => converter.ToTypesenseValue(valueProvider?.GetValue(instance)) != null;
         }
 
         return jsonProperty;

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearch.I.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearch.I.cs
@@ -1,0 +1,8 @@
+using N3O.Umbraco.Search.Typesense.Models;
+using System.Threading.Tasks;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public interface ITypesenseSearch<T> where T : SearchDocument {
+    Task ApplyAsync(ITypesenseSearchBuilder<T> q);
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearch.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearch.cs
@@ -1,0 +1,16 @@
+using N3O.Umbraco.Search.Typesense.Models;
+using System.Threading.Tasks;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public abstract class TypesenseSearch<T> : ITypesenseSearch<T> where T : SearchDocument {
+    public Task ApplyAsync(ITypesenseSearchBuilder<T> q) {
+        Q = q;
+
+        return ApplyAsync();
+    }
+
+    protected abstract Task ApplyAsync();
+
+    protected ITypesenseSearchBuilder<T> Q { get; private set; }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.Custom.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.Custom.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public partial class TypesenseSearchBuilder<T> {
+    private readonly List<Action<SearchParameters>> _customActions = new();
+
+    public ITypesenseSearchBuilder<T> Custom(Action<SearchParameters> action) {
+        _customActions.Add(action);
+
+        return this;
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.Filter.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.Filter.cs
@@ -1,0 +1,57 @@
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Search.Typesense.Queries;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public partial class TypesenseSearchBuilder<T> {
+    private readonly List<ITypesenseSearch<T>> _appliedSearches = new();
+    private readonly List<ParameterizedTypesenseText> _filterTexts = new();
+
+    public ITypesenseSearchBuilder<T> Compose<TSearch, TCriteria>(TCriteria criteria)
+        where TSearch : ITypesenseSearch<T> {
+        return Compose<TSearch>(criteria);
+    }
+
+    public ITypesenseSearchBuilder<T> Compose<TSearch>(params object[] criteria)
+        where TSearch : ITypesenseSearch<T> {
+        var search = _typesenseSearchFactory.GetSearch<T, TSearch>(criteria);
+
+        _appliedSearches.Add(search);
+
+        return this;
+    }
+
+    public ITypesenseSearchBuilder<T> Filter(ParameterizedTypesenseText parameterizedTypesenseText) {
+        return Filter(parameterizedTypesenseText, null);
+    }
+
+    public ITypesenseSearchBuilder<T> Filter<TKey>(Expression<Func<T, TKey>> pathExpression,
+                                                   string expression,
+                                                   params Action<ParameterizedTypesenseText>[] filterActions) {
+        var parameterizedSearch = ParameterizedTypesenseText.Create(pathExpression, expression);
+
+        return Filter(parameterizedSearch, filterActions);
+    }
+
+    public ITypesenseSearchBuilder<T> Filter(Action<ITypesenseClauseBuilder<T>> buildClause) {
+        var clauseBuilder = new TypesenseClauseBuilder<T>();
+
+        buildClause(clauseBuilder);
+
+        return Filter(clauseBuilder.Build());
+    }
+
+    private ITypesenseSearchBuilder<T> Filter(ParameterizedTypesenseText parameterizedTypesenseText,
+                                              IEnumerable<Action<ParameterizedTypesenseText>> filterActions) {
+        if ((parameterizedTypesenseText?.Text).HasValue()) {
+            filterActions.Do(e => e?.Invoke(parameterizedTypesenseText));
+
+            _filterTexts.Add(parameterizedTypesenseText);
+        }
+
+        return this;
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.I.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.I.cs
@@ -1,0 +1,42 @@
+using N3O.Umbraco.Search.Typesense.Models;
+using N3O.Umbraco.Search.Typesense.Queries;
+using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public interface ITypesenseSearchBuilder<T> where T : SearchDocument {
+    ITypesenseSearchBuilder<T> Compose<TSearch, TCriteria>(TCriteria criteria)
+        where TSearch : ITypesenseSearch<T>;
+
+    ITypesenseSearchBuilder<T> Compose<TSearch>(params object[] criteria)
+        where TSearch : ITypesenseSearch<T>;
+
+    ITypesenseSearchBuilder<T> Custom(Action<SearchParameters> action);
+
+    ITypesenseSearchBuilder<T> Filter(ParameterizedTypesenseText parameterizedTypesenseText);
+
+    ITypesenseSearchBuilder<T> Filter<TKey>(Expression<Func<T, TKey>> pathExpression,
+                                            string expression,
+                                            params Action<ParameterizedTypesenseText>[] filterActions);
+
+    ITypesenseSearchBuilder<T> Filter(Action<ITypesenseClauseBuilder<T>> buildClause);
+
+    ITypesenseSearchBuilder<T> Query<TField>(string text,
+                                             params Expression<Func<T, TField>>[] fieldSelectors);
+
+    ITypesenseSearchBuilder<T> Query(string text,
+                                     params (Expression<Func<T, object>> field, int weight)[] weightedFields);
+
+    ITypesenseSearchBuilder<T> OrderBy<TField>(Expression<Func<T, TField>> fieldSelector);
+
+    ITypesenseSearchBuilder<T> OrderByDescending<TField>(Expression<Func<T, TField>> fieldSelector);
+
+    ITypesenseSearchBuilder<T> ThenBy<TField>(Expression<Func<T, TField>> fieldSelector);
+
+    ITypesenseSearchBuilder<T> ThenByDescending<TField>(Expression<Func<T, TField>> fieldSelector);
+
+    Task<SearchParameters> BuildAsync();
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.Query.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.Query.cs
@@ -1,0 +1,33 @@
+using N3O.Umbraco.Extensions;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public partial class TypesenseSearchBuilder<T> {
+    private string _queryFields;
+    private string _queryText = "*";
+
+    public ITypesenseSearchBuilder<T> Query<TField>(string text,
+                                                    params Expression<Func<T, TField>>[] fieldSelectors) {
+        var fields = fieldSelectors.Select(TypesenseField.Get).ToList();
+
+        _queryText = text;
+        _queryFields = fields.ToCsv();
+
+        return this;
+    }
+
+    public ITypesenseSearchBuilder<T> Query(string text,
+                                            params (Expression<Func<T, object>> field, int weight)[] weightedFields) {
+        var fields = weightedFields.Select(x => TypesenseField.Get(x.field)).ToList();
+        var weights = weightedFields.Select(x => x.weight.ToString(CultureInfo.InvariantCulture)).ToList();
+
+        _queryText = text;
+        _queryFields = fields.ToCsv();
+
+        return Custom(p => p.QueryByWeights = weights.ToCsv());
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.Sort.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.Sort.cs
@@ -1,0 +1,52 @@
+using N3O.Umbraco.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public partial class TypesenseSearchBuilder<T> {
+    private const string Ascending = "asc";
+    private const string Descending = "desc";
+
+    private readonly List<(string Field, string Direction)> _orderBy = new();
+
+    public ITypesenseSearchBuilder<T> OrderBy<TField>(Expression<Func<T, TField>> fieldSelector) {
+        return ApplySort(fieldSelector, Ascending, false);
+    }
+
+    public ITypesenseSearchBuilder<T> OrderByDescending<TField>(Expression<Func<T, TField>> fieldSelector) {
+        return ApplySort(fieldSelector, Descending, false);
+    }
+
+    public ITypesenseSearchBuilder<T> ThenBy<TField>(Expression<Func<T, TField>> fieldSelector) {
+        return ApplySort(fieldSelector, Ascending, true);
+    }
+
+    public ITypesenseSearchBuilder<T> ThenByDescending<TField>(Expression<Func<T, TField>> fieldSelector) {
+        return ApplySort(fieldSelector, Descending, true);
+    }
+
+    private ITypesenseSearchBuilder<T> ApplySort<TField>(Expression<Func<T, TField>> fieldSelector,
+                                                         string direction,
+                                                         bool preserveExistingSort) {
+        if (!preserveExistingSort) {
+            _orderBy.Clear();
+        }
+
+        var field = TypesenseField.Get(fieldSelector);
+
+        _orderBy.Add((field, direction));
+
+        return this;
+    }
+
+    private string GetSortBy() {
+        if (_orderBy.Any()) {
+            return _orderBy.Select(x => $"{x.Field}:{x.Direction}").ToCsv();
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchBuilder.cs
@@ -1,0 +1,47 @@
+using N3O.Umbraco.Extensions;
+using N3O.Umbraco.Search.Typesense.Models;
+using N3O.Umbraco.Search.Typesense.Queries;
+using System;
+using System.Threading.Tasks;
+using Typesense;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public partial class TypesenseSearchBuilder<T> : ITypesenseSearchBuilder<T> where T : SearchDocument {
+    private readonly ITypesenseSearchFactory _typesenseSearchFactory;
+    private bool _built;
+
+    public TypesenseSearchBuilder(ITypesenseSearchFactory typesenseSearchFactory) {
+        _typesenseSearchFactory = typesenseSearchFactory;
+    }
+
+    public async Task<SearchParameters> BuildAsync() {
+        if (_built) {
+            throw new Exception($"{nameof(BuildAsync)} can only be called once per {nameof(TypesenseSearchBuilder<T>)} instance");
+        }
+
+        _built = true;
+
+        foreach (var search in _appliedSearches) {
+            await search.ApplyAsync(this);
+        }
+
+        var searchParameters = new SearchParameters(_queryText, _queryFields ?? string.Empty);
+
+        searchParameters.SortBy = GetSortBy();
+
+        var filterBy = ParameterizedTypesenseText.Empty();
+
+        foreach (var filterText in _filterTexts) {
+            filterBy.And(filterText);
+        }
+
+        if (!filterBy.IsEmpty) {
+            searchParameters.FilterBy = filterBy.ToString();
+        }
+
+        _customActions.Do(x => x(searchParameters));
+
+        return searchParameters;
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchFactory.I.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchFactory.I.cs
@@ -1,0 +1,9 @@
+using N3O.Umbraco.Search.Typesense.Models;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public interface ITypesenseSearchFactory {
+    TSearch GetSearch<TDocument, TSearch>(params object[] criteria)
+        where TDocument : SearchDocument
+        where TSearch : ITypesenseSearch<TDocument>;
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchFactory.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/Services/TypesenseSearchFactory.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+using N3O.Umbraco.Search.Typesense.Models;
+using System;
+
+namespace N3O.Umbraco.Search.Typesense;
+
+public class TypesenseSearchFactory : ITypesenseSearchFactory {
+    private readonly IServiceProvider _serviceProvider;
+
+    public TypesenseSearchFactory(IServiceProvider serviceProvider) {
+        _serviceProvider = serviceProvider;
+    }
+
+    public TSearch GetSearch<TDocument, TSearch>(params object[] criteria)
+        where TDocument : SearchDocument
+        where TSearch : ITypesenseSearch<TDocument> {
+        return (TSearch) ActivatorUtilities.CreateInstance(_serviceProvider, typeof(TSearch), criteria);
+    }
+}

--- a/src/Search/N3O.Umbraco.Search.Typesense/TypesenseSearchComposer.cs
+++ b/src/Search/N3O.Umbraco.Search.Typesense/TypesenseSearchComposer.cs
@@ -16,6 +16,8 @@ public class TypesenseSearchComposer : Composer {
         builder.Services.AddSingleton<IConfigureOptions<Config>, TypesenseOptions>();
         builder.Services.AddTransient(typeof(ISearchDocumentBuilder<>), typeof(SearchDocumentBuilder<>));
         builder.Services.AddTransient(typeof(ISearcher<>), typeof(Searcher<>));
+        builder.Services.AddTransient(typeof(ITypesenseSearchBuilder<>), typeof(TypesenseSearchBuilder<>));
+        builder.Services.AddTransient<ITypesenseSearchFactory, TypesenseSearchFactory>();
         builder.Services.AddSingleton<ITypesenseJsonProvider, TypesenseJsonProvider>();
 
         builder.Services.AddOpenApiDocument(TypesenseConstants.BackOfficeApiName);


### PR DESCRIPTION
## Linked work issue

no-work-issue

## Summary

The Typesense package here and the equivalent implementation used by our backend services began as the same code, but the backend copy has moved on over the last few months. This brings the package back in line, so a search document written against either one behaves the same way.

**Collections are versioned.** `[Collection]` now carries a version alongside the name, and each version exists as a physical collection named `{name}_v{version}` with a Typesense alias at the plain name pointing to it. Indexing and searching only ever address the alias, so rolling out a schema change is a one-line version bump: on startup the new physical collection is created, populated by a reindex, the alias is flipped to it, and the previous collection is dropped. Because that reindex can be slow on a large collection it runs as a background job instead of blocking application startup. A site indexed before this change has a real collection occupying the name the alias now needs, and Typesense will not hold both under one name, so the migration detects that case and removes the collection before creating the alias — an installation upgrading to this version migrates itself without manual intervention.

**Document schemas can describe nested objects.** Object and object-collection properties used to have no useful representation, so they were either skipped or hand-flattened into extra string properties. The field list is now expanded from the JSON serializer contract into the dotted paths Typesense expects — `category.name`, `category.icon_url`, array members included — with `enable_nested_fields` set on the collection, so a document can expose a real object graph and clients can read it back at those paths.

**Value conversion is pluggable.** `ITypesenseConverter` implementations are discovered by type scan and applied per property, so a type indexes as the primitive Typesense actually stores without a bespoke `JsonConverter` on every document that mentions it. Converters ship for `Instant`, `LocalDate`, `LocalDateTime`, `LocalTime`, `DateTimeOffset` and `Uri`, with typed bases for the primitive targets. A converter that yields null omits the property entirely, which plain null handling cannot express because the source value is not itself null.

**Queries can be written against the document type.** `TypesenseField.Get(x => x.Title)` resolves the indexed field name from the property, so a rename is a compile error instead of a silently stale string. `ParameterizedTypesenseText` composes filter expressions with parameter substitution and escaping, and `ITypesenseSearchBuilder<T>` assembles query, filter, sort and paging in one place.

**Smaller parity fixes.** `ISearchIndexer` can now report which collection it indexes and index into a nominated collection, which is what lets the migration populate a new version before the alias moves. `SearchDocument` can parse its own composite id back into content key and culture. An exported-document model was added for document export. The `Typesense` client goes from 8.3.0 to 8.5.0. Duplicate field and index definitions are now rejected when a collection is registered rather than surfacing later as a Typesense error.

Two notes for anyone taking this version. `PageDocument`'s timestamp fields are now `int64` rather than string, which is a schema change; its collection version is bumped accordingly. Consuming sites define their own document types, so any of theirs that index a timestamp as a string need the same field-type change plus a collection version bump — that is a follow-up in those repositories, not something this package can do for them.

## Test plan

- [x] The package builds with 0 errors. The only warning is the pre-existing obsolete-member one that is already on `main`.
- [x] 235 assertions were executed against a live Typesense 29.0 container, covering every converter (including null omission and the member-level dispatch taking precedence over serializer-level converters), nested expansion for objects, object arrays and lookups, schema and duplicate-definition validation, typed field resolution, parameterized filter composition and the search builder's query, filter, sort and paging output, indexer collection targeting, and a full alias migration end to end — create the new physical collection, populate it, flip the alias, delete the old one — including the upgrade path from an unversioned collection.
- [x] Reverse-checked, so the assertions are load-bearing rather than vacuous. Disabling the unversioned-collection handling makes the migration fail with Typesense's own `Name 'legacy' conflicts with an existing collection name.` Reverting the multiple-index fix reproduces `AmbiguousMatchException: Multiple custom attributes of the same type 'IndexAttribute'`. Renaming a document property breaks the typed field helper at compile time where the equivalent string literal compiled happily.
- [ ] The harness used above is a temporary local console runner and is deliberately not part of this diff.
- [ ] Not verified here: behaviour inside a consuming site, which cannot compile against this until the package is published.
